### PR TITLE
Revert stream subscription retention default to auto remove

### DIFF
--- a/stream-android-core/src/main/java/io/getstream/android/core/api/subscribe/StreamSubscriptionManager.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/api/subscribe/StreamSubscriptionManager.kt
@@ -44,7 +44,7 @@ interface StreamSubscriptionManager<T> {
      *
      * @property retention Controls how the manager retains the listener reference.
      */
-    data class Options(val retention: Retention = Retention.KEEP_UNTIL_CANCELLED) {
+    data class Options(val retention: Retention = Retention.AUTO_REMOVE) {
         /** Retention policy for a subscribed listener. */
         enum class Retention {
             /**


### PR DESCRIPTION
We decided to use weak subscriptions as a default for now and see how it goes