### PR TITLE
Close code and utils

### DIFF
--- a/stream-android-core/src/main/java/io/getstream/android/core/api/model/exceptions/Exceptions.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/api/model/exceptions/Exceptions.kt
@@ -43,7 +43,7 @@ public open class StreamClientException(message: String = "", cause: Throwable? 
  */
 @StreamPublishedApi
 public class StreamEndpointException(
-    message: String = "",
+    message: String? = null,
     public val apiError: StreamEndpointErrorData? = null,
     cause: Throwable? = null,
 ) : IOException(message, cause)

--- a/stream-android-core/src/main/java/io/getstream/android/core/api/socket/StreamWebSocket.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/api/socket/StreamWebSocket.kt
@@ -15,11 +15,14 @@
  */
 package io.getstream.android.core.api.socket
 
+import io.getstream.android.core.annotations.StreamDelicateApi
 import io.getstream.android.core.annotations.StreamInternalApi
 import io.getstream.android.core.api.log.StreamLogger
 import io.getstream.android.core.api.model.config.StreamSocketConfig
 import io.getstream.android.core.api.socket.listeners.StreamWebSocketListener
 import io.getstream.android.core.api.subscribe.StreamSubscriptionManager
+import io.getstream.android.core.internal.socket.SocketConstants.CLOSE_SOCKET_CODE
+import io.getstream.android.core.internal.socket.SocketConstants.CLOSE_SOCKET_REASON
 import io.getstream.android.core.internal.socket.StreamWebSocketImpl
 
 /**
@@ -42,13 +45,13 @@ public interface StreamWebSocket<T : StreamWebSocketListener> : StreamSubscripti
     public fun open(config: StreamSocketConfig): Result<Unit>
 
     /**
-     * Closes the WebSocket connection.
+     * Closes the WebSocket connection with a custom code and reason.
      *
-     * Once closed, no further messages can be sent or received.
-     *
-     * @return A [Result] indicating whether the connection was successfully closed.
+     * @param code The closure status code
+     * @param reason The reason message provided by the peer, if any.
+     * @return `true` if the close operation was successful, `false` otherwise.
      */
-    public fun close(): Result<Unit>
+    public fun close(code: Int = CLOSE_SOCKET_CODE, reason: String = CLOSE_SOCKET_REASON): Result<Unit>
 
     /**
      * Sends binary data through the WebSocket connection.

--- a/stream-android-core/src/main/java/io/getstream/android/core/api/socket/StreamWebSocket.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/api/socket/StreamWebSocket.kt
@@ -15,7 +15,6 @@
  */
 package io.getstream.android.core.api.socket
 
-import io.getstream.android.core.annotations.StreamDelicateApi
 import io.getstream.android.core.annotations.StreamInternalApi
 import io.getstream.android.core.api.log.StreamLogger
 import io.getstream.android.core.api.model.config.StreamSocketConfig
@@ -51,7 +50,10 @@ public interface StreamWebSocket<T : StreamWebSocketListener> : StreamSubscripti
      * @param reason The reason message provided by the peer, if any.
      * @return `true` if the close operation was successful, `false` otherwise.
      */
-    public fun close(code: Int = CLOSE_SOCKET_CODE, reason: String = CLOSE_SOCKET_REASON): Result<Unit>
+    public fun close(
+        code: Int = CLOSE_SOCKET_CODE,
+        reason: String = CLOSE_SOCKET_REASON,
+    ): Result<Unit>
 
     /**
      * Sends binary data through the WebSocket connection.

--- a/stream-android-core/src/main/java/io/getstream/android/core/api/utils/Response.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/api/utils/Response.kt
@@ -1,0 +1,20 @@
+package io.getstream.android.core.api.utils
+
+import io.getstream.android.core.api.model.exceptions.StreamEndpointErrorData
+import io.getstream.android.core.api.model.exceptions.StreamEndpointException
+import io.getstream.android.core.api.serialization.StreamJsonSerialization
+import okhttp3.Response
+
+/**
+ * Extracts the API error from the response body.
+ *
+ * @param with The JSON parser to use for parsing the response body.
+ * @return The API error, or a failure if the response body could not be parsed.
+ * @receiver The response to extract the error from.
+ */
+public fun Response.toErrorData(with: StreamJsonSerialization): Result<StreamEndpointErrorData> =
+    runCatching {
+        peekBody(Long.MAX_VALUE).string()
+    }.flatMap {
+        with.fromJson(it, StreamEndpointErrorData::class.java)
+    }

--- a/stream-android-core/src/main/java/io/getstream/android/core/api/utils/Response.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/api/utils/Response.kt
@@ -1,7 +1,21 @@
+/*
+ * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-core-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.getstream.android.core.api.utils
 
 import io.getstream.android.core.api.model.exceptions.StreamEndpointErrorData
-import io.getstream.android.core.api.model.exceptions.StreamEndpointException
 import io.getstream.android.core.api.serialization.StreamJsonSerialization
 import okhttp3.Response
 
@@ -13,8 +27,5 @@ import okhttp3.Response
  * @receiver The response to extract the error from.
  */
 public fun Response.toErrorData(with: StreamJsonSerialization): Result<StreamEndpointErrorData> =
-    runCatching {
-        peekBody(Long.MAX_VALUE).string()
-    }.flatMap {
-        with.fromJson(it, StreamEndpointErrorData::class.java)
-    }
+    runCatching { peekBody(Long.MAX_VALUE).string() }
+        .flatMap { with.fromJson(it, StreamEndpointErrorData::class.java) }

--- a/stream-android-core/src/main/java/io/getstream/android/core/internal/http/interceptor/StreamEndpointErrorInterceptor.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/internal/http/interceptor/StreamEndpointErrorInterceptor.kt
@@ -36,7 +36,9 @@ internal class StreamEndpointErrorInterceptor(private val jsonParser: StreamJson
 
         if (!response.isSuccessful) {
             // Try to parse a Stream API error from the response body
-            response.toErrorData(jsonParser).fold(
+            response
+                .toErrorData(jsonParser)
+                .fold(
                     onSuccess = { apiError ->
                         throw StreamEndpointException(
                             "Failed request: ${chain.request().url}",

--- a/stream-android-core/src/main/java/io/getstream/android/core/internal/http/interceptor/StreamEndpointErrorInterceptor.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/internal/http/interceptor/StreamEndpointErrorInterceptor.kt
@@ -15,11 +15,10 @@
  */
 package io.getstream.android.core.internal.http.interceptor
 
-import io.getstream.android.core.api.model.exceptions.StreamEndpointErrorData
 import io.getstream.android.core.api.model.exceptions.StreamEndpointException
 import io.getstream.android.core.api.serialization.StreamJsonSerialization
+import io.getstream.android.core.api.utils.toErrorData
 import kotlin.fold
-import kotlin.jvm.java
 import okhttp3.Interceptor
 import okhttp3.Response
 
@@ -37,10 +36,7 @@ internal class StreamEndpointErrorInterceptor(private val jsonParser: StreamJson
 
         if (!response.isSuccessful) {
             // Try to parse a Stream API error from the response body
-            val errorBody = response.peekBody(Long.MAX_VALUE).string()
-            jsonParser
-                .fromJson(errorBody, StreamEndpointErrorData::class.java)
-                .fold(
+            response.toErrorData(jsonParser).fold(
                     onSuccess = { apiError ->
                         throw StreamEndpointException(
                             "Failed request: ${chain.request().url}",

--- a/stream-android-core/src/main/java/io/getstream/android/core/internal/socket/StreamSocketSession.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/internal/socket/StreamSocketSession.kt
@@ -122,10 +122,10 @@ internal class StreamSocketSession<T>(
      * Terminates the active socket session and performs a best-effort shutdown of all components.
      *
      * The method emits a `StreamConnectionState.Disconnected` state (embedding [error] when
-     * provided), cancels the active socket subscription, closes the underlying
-     * [StreamWebSocket], and stops the health monitor and batch processor. Subsequent invocations
-     * are idempotent: listeners are only notified on the first call while the socket close is
-     * still attempted every time.
+     * provided), cancels the active socket subscription, closes the underlying [StreamWebSocket],
+     * and stops the health monitor and batch processor. Subsequent invocations are idempotent:
+     * listeners are only notified on the first call while the socket close is still attempted every
+     * time.
      *
      * @param error Optional cause that is propagated to subscribers via
      *   `StreamConnectionState.Disconnected(error)`.
@@ -140,7 +140,9 @@ internal class StreamSocketSession<T>(
         code: Int = SocketConstants.CLOSE_SOCKET_CODE,
         reason: String = SocketConstants.CLOSE_SOCKET_REASON,
     ): Result<Unit> {
-        logger.d { "[disconnect] Disconnecting socket, code: $code, reason: $reason, error: $error" }
+        logger.d {
+            "[disconnect] Disconnecting socket, code: $code, reason: $reason, error: $error"
+        }
         if (!closingByUs.getAndSet(true)) {
             val newState =
                 if (error == null) {
@@ -153,7 +155,8 @@ internal class StreamSocketSession<T>(
         // Cancel subscriptions before closing to avoid duplicate callbacks.
         socketSubscription?.cancel()
         val closeRes =
-            internalSocket.close(code, reason)
+            internalSocket
+                .close(code, reason)
                 .onSuccess { logger.d { "[disconnect] Socket closed" } }
                 .onFailure { throwable ->
                     logger.e { "[disconnect] Failed to close socket. ${throwable.message}" }
@@ -165,8 +168,8 @@ internal class StreamSocketSession<T>(
     /**
      * Opens the socket and completes the Stream authentication handshake for the provided user.
      *
-     * The call subscribes to lifecycle events, opens the underlying [StreamWebSocket], performs
-     * the auth handshake, starts the health monitor once connected, and emits all intermediate
+     * The call subscribes to lifecycle events, opens the underlying [StreamWebSocket], performs the
+     * auth handshake, starts the health monitor once connected, and emits all intermediate
      * [StreamConnectionState] updates to registered [StreamClientListener] instances. When the
      * coroutine is cancelled or any step fails, all temporary subscriptions are cleaned up and the
      * failure is propagated via the returned [Result].
@@ -412,19 +415,26 @@ internal class StreamSocketSession<T>(
 
                     override fun onFailure(t: Throwable, response: Response?) {
                         val apiError = response?.toErrorData(jsonSerialization)?.getOrNull()
-                        val exception = StreamEndpointException(
-                            message = "Socket failed during connection",
-                            cause = t,
-                            apiError = apiError,
-                        )
-                        logger.e(exception) { "[onFailure] Socket failure during connection: ${exception.message}" }
+                        val exception =
+                            StreamEndpointException(
+                                message = "Socket failed during connection",
+                                cause = t,
+                                apiError = apiError,
+                            )
+                        logger.e(exception) {
+                            "[onFailure] Socket failure during connection: ${exception.message}"
+                        }
                         failure(exception)
                     }
 
                     override fun onClosed(code: Int, reason: String) {
                         val exception =
-                            IOException("Socket closed during connection. Code: $code, Reason: $reason")
-                        logger.e(exception) { "[onClosed] Socket closed during connection. Code: $code, Reason: $reason" }
+                            IOException(
+                                "Socket closed during connection. Code: $code, Reason: $reason"
+                            )
+                        logger.e(exception) {
+                            "[onClosed] Socket closed during connection. Code: $code, Reason: $reason"
+                        }
                         failure(exception)
                     }
                 }

--- a/stream-android-core/src/main/java/io/getstream/android/core/internal/socket/StreamWebSocketImpl.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/internal/socket/StreamWebSocketImpl.kt
@@ -23,8 +23,6 @@ import io.getstream.android.core.api.socket.StreamWebSocketFactory
 import io.getstream.android.core.api.socket.listeners.StreamWebSocketListener
 import io.getstream.android.core.api.subscribe.StreamSubscription
 import io.getstream.android.core.api.subscribe.StreamSubscriptionManager
-import io.getstream.android.core.internal.socket.SocketConstants.CLOSE_SOCKET_CODE
-import io.getstream.android.core.internal.socket.SocketConstants.CLOSE_SOCKET_REASON
 import java.io.IOException
 import okhttp3.Response
 import okhttp3.WebSocket

--- a/stream-android-core/src/main/java/io/getstream/android/core/internal/socket/StreamWebSocketImpl.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/internal/socket/StreamWebSocketImpl.kt
@@ -49,9 +49,9 @@ internal open class StreamWebSocketImpl<T : StreamWebSocketListener>(
                 .getOrThrow()
     }
 
-    override fun close(): Result<Unit> = withSocket {
-        logger.d { "[close] Closing socket" }
-        socket.close(CLOSE_SOCKET_CODE, CLOSE_SOCKET_REASON)
+    override fun close(code: Int, reason: String): Result<Unit> = withSocket {
+        logger.d { "[close#withReason] Closing socket. Code: $code, Reason: $reason" }
+        socket.close(code, reason)
     }
 
     override fun send(data: ByteArray): Result<ByteArray> = withSocket {

--- a/stream-android-core/src/test/java/io/getstream/android/core/api/utils/ResponseTest.kt
+++ b/stream-android-core/src/test/java/io/getstream/android/core/api/utils/ResponseTest.kt
@@ -1,14 +1,29 @@
+/*
+ * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-core-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.getstream.android.core.api.utils
 
 import io.getstream.android.core.api.model.exceptions.StreamEndpointErrorData
 import io.getstream.android.core.api.serialization.StreamJsonSerialization
+import io.mockk.every
+import io.mockk.mockk
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.Response
 import okhttp3.ResponseBody
 import org.junit.Assert.*
 import org.junit.Test
-import io.mockk.every
-import io.mockk.mockk
 
 class ResponseTest {
 
@@ -17,14 +32,16 @@ class ResponseTest {
         val jsonSerialization = mockk<StreamJsonSerialization>()
         val errorData = StreamEndpointErrorData(1000, "detail", "field")
         val responseBody = "{\"code\":\"code\",\"detail\":\"detail\",\"field\":\"field\"}"
-        val response = Response.Builder()
-            .code(400)
-            .message("Bad Request")
-            .request(okhttp3.Request.Builder().url("http://localhost").build())
-            .protocol(okhttp3.Protocol.HTTP_1_1)
-            .body(ResponseBody.create("application/json".toMediaTypeOrNull(), responseBody))
-            .build()
-        every { jsonSerialization.fromJson(any(), StreamEndpointErrorData::class.java) } returns Result.success(errorData)
+        val response =
+            Response.Builder()
+                .code(400)
+                .message("Bad Request")
+                .request(okhttp3.Request.Builder().url("http://localhost").build())
+                .protocol(okhttp3.Protocol.HTTP_1_1)
+                .body(ResponseBody.create("application/json".toMediaTypeOrNull(), responseBody))
+                .build()
+        every { jsonSerialization.fromJson(any(), StreamEndpointErrorData::class.java) } returns
+            Result.success(errorData)
         val result = response.toErrorData(jsonSerialization)
         assertTrue(result.isSuccess)
         assertEquals(errorData, result.getOrNull())
@@ -34,14 +51,16 @@ class ResponseTest {
     fun `toErrorData returns failure when parsing throws`() {
         val jsonSerialization = mockk<StreamJsonSerialization>()
         val responseBody = "invalid json"
-        val response = Response.Builder()
-            .code(400)
-            .message("Bad Request")
-            .request(okhttp3.Request.Builder().url("http://localhost").build())
-            .protocol(okhttp3.Protocol.HTTP_1_1)
-            .body(ResponseBody.create("application/json".toMediaTypeOrNull(), responseBody))
-            .build()
-        every { jsonSerialization.fromJson(any(), StreamEndpointErrorData::class.java) } returns Result.failure(IllegalArgumentException("Parse error"))
+        val response =
+            Response.Builder()
+                .code(400)
+                .message("Bad Request")
+                .request(okhttp3.Request.Builder().url("http://localhost").build())
+                .protocol(okhttp3.Protocol.HTTP_1_1)
+                .body(ResponseBody.create("application/json".toMediaTypeOrNull(), responseBody))
+                .build()
+        every { jsonSerialization.fromJson(any(), StreamEndpointErrorData::class.java) } returns
+            Result.failure(IllegalArgumentException("Parse error"))
         val result = response.toErrorData(jsonSerialization)
         assertTrue(result.isFailure)
         assertTrue(result.exceptionOrNull() is IllegalArgumentException)

--- a/stream-android-core/src/test/java/io/getstream/android/core/api/utils/ResponseTest.kt
+++ b/stream-android-core/src/test/java/io/getstream/android/core/api/utils/ResponseTest.kt
@@ -1,0 +1,50 @@
+package io.getstream.android.core.api.utils
+
+import io.getstream.android.core.api.model.exceptions.StreamEndpointErrorData
+import io.getstream.android.core.api.serialization.StreamJsonSerialization
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
+import okhttp3.Response
+import okhttp3.ResponseBody
+import org.junit.Assert.*
+import org.junit.Test
+import io.mockk.every
+import io.mockk.mockk
+
+class ResponseTest {
+
+    @Test
+    fun `toErrorData returns success when parsing is successful`() {
+        val jsonSerialization = mockk<StreamJsonSerialization>()
+        val errorData = StreamEndpointErrorData(1000, "detail", "field")
+        val responseBody = "{\"code\":\"code\",\"detail\":\"detail\",\"field\":\"field\"}"
+        val response = Response.Builder()
+            .code(400)
+            .message("Bad Request")
+            .request(okhttp3.Request.Builder().url("http://localhost").build())
+            .protocol(okhttp3.Protocol.HTTP_1_1)
+            .body(ResponseBody.create("application/json".toMediaTypeOrNull(), responseBody))
+            .build()
+        every { jsonSerialization.fromJson(any(), StreamEndpointErrorData::class.java) } returns Result.success(errorData)
+        val result = response.toErrorData(jsonSerialization)
+        assertTrue(result.isSuccess)
+        assertEquals(errorData, result.getOrNull())
+    }
+
+    @Test
+    fun `toErrorData returns failure when parsing throws`() {
+        val jsonSerialization = mockk<StreamJsonSerialization>()
+        val responseBody = "invalid json"
+        val response = Response.Builder()
+            .code(400)
+            .message("Bad Request")
+            .request(okhttp3.Request.Builder().url("http://localhost").build())
+            .protocol(okhttp3.Protocol.HTTP_1_1)
+            .body(ResponseBody.create("application/json".toMediaTypeOrNull(), responseBody))
+            .build()
+        every { jsonSerialization.fromJson(any(), StreamEndpointErrorData::class.java) } returns Result.failure(IllegalArgumentException("Parse error"))
+        val result = response.toErrorData(jsonSerialization)
+        assertTrue(result.isFailure)
+        assertTrue(result.exceptionOrNull() is IllegalArgumentException)
+        assertEquals("Parse error", result.exceptionOrNull()?.message)
+    }
+}


### PR DESCRIPTION
### Goal
Introduce close code and reason for closing the socket when disconnection.

### Implementation
Add `code` and `reason` as parameters to disconnect and propagate them over to the `socket.close()`

### Testing
Covered by unit tests

### Checklist
- [ ] Issue linked (if any)  
- [x] Tests/docs updated
- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required for external contributors)
