### PR TITLE
Align internal sort package to the public one.

### DIFF
--- a/stream-android-core/src/main/java/io/getstream/android/core/api/sort/SortDirection.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/api/sort/SortDirection.kt
@@ -15,11 +15,14 @@
  */
 package io.getstream.android.core.api.sort
 
+import io.getstream.android.core.annotations.StreamPublishedApi
+
 /**
  * The direction of a sort operation. This enum defines whether a sort should be performed in
  * ascending (forward) or descending (reverse) order. The raw values correspond to the values
  * expected by the remote API.
  */
+@StreamPublishedApi
 public enum class SortDirection(public val value: Int) {
     /** Sort in ascending order (A to Z, 1 to 9, etc.). */
     FORWARD(1),

--- a/stream-android-core/src/main/java/io/getstream/android/core/api/sort/SortField.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/api/sort/SortField.kt
@@ -17,7 +17,7 @@ package io.getstream.android.core.api.sort
 
 import io.getstream.android.core.annotations.StreamInternalApi
 import io.getstream.android.core.annotations.StreamPublishedApi
-import io.getstream.android.core.internal.filter.SortFieldImpl
+import io.getstream.android.core.internal.sort.SortFieldImpl
 
 /**
  * A protocol that defines a sortable field for a specific model type.

--- a/stream-android-core/src/main/java/io/getstream/android/core/internal/sort/SortFieldImpl.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/internal/sort/SortFieldImpl.kt
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.getstream.android.core.internal.filter
+package io.getstream.android.core.internal.sort
 
 import io.getstream.android.core.api.sort.AnySortComparator
 import io.getstream.android.core.api.sort.SortComparator


### PR DESCRIPTION
### Goal
Align the `internal` `sort` package with the `public` one.

### Implementation
- Move `SortFieldImpl` from `internal.filter` to `internal.sort`
- (additional) Mark `SortDirection` as published API

### Testing
- Run the sample to check for compilation errors

### Checklist
- [ ] Issue linked (if any)  
- [ ] Tests/docs updated
- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required for external contributors)
