### PR TITLE
Initialize planning infrastructure and map code-base

### DIFF
--- a/.planning/PROJECT.md
+++ b/.planning/PROJECT.md
@@ -1,0 +1,70 @@
+# Stream Android Core
+
+## What This Is
+
+Internal foundational library that powers all of Stream's Android SDKs (Chat, Video, Feeds). Provides shared infrastructure for real-time WebSocket connectivity, JWT authentication, connection state management, and reliability patterns. Not for public consumption — used only by Stream product SDKs.
+
+## Core Value
+
+Reliable real-time connectivity that automatically recovers from network disruptions and app lifecycle changes.
+
+## Requirements
+
+### Validated
+
+- ✓ WebSocket connection with JWT authentication — existing
+- ✓ Connection state machine (Idle → Opening → Authenticating → Connected → Disconnected) — existing
+- ✓ Automatic reconnection on network recovery and app resume — existing
+- ✓ Token management with single-flight refresh deduplication — existing
+- ✓ Health monitoring with configurable heartbeat (25s) and liveness timeout (60s) — existing
+- ✓ Event batching with adaptive window (100ms-1s) — existing
+- ✓ HTTP interceptor chain (API key, auth, client info, connection ID, error parsing) — existing
+- ✓ Network and lifecycle monitoring via Android system callbacks — existing
+- ✓ Watch registry with automatic re-watch on reconnection — existing
+- ✓ Result-based error handling throughout — existing
+- ✓ Thread-safe APIs with coroutine-based concurrency — existing
+- ✓ Moshi JSON serialization with KSP code generation — existing
+- ✓ Custom lint rules for API consistency — existing
+
+### Active
+
+(None yet — ready for next milestone)
+
+### Out of Scope
+
+- Direct database/persistence integration — product SDKs handle their own storage
+- UI components — this is infrastructure only
+- Public API for end consumers — internal to Stream SDKs
+
+## Context
+
+**Purpose:** Shared foundation across Chat, Video, and Feeds Android SDKs. Changes here affect all product SDKs.
+
+**Architecture:** Layered client-server with pluggable components. API layer exposes stable contracts; internal layer implements them. Processing layer handles concurrency patterns (single-flight, batching, serial queues).
+
+**Visibility annotations:**
+- `@StreamPublishedApi` — Stable, SDK-exposed (breaking changes require major version bump)
+- `@StreamInternalApi` — Internal infrastructure, may change without notice
+- `@StreamDelicateApi` — Advanced APIs requiring careful use
+
+**Current version:** 2.0.0
+
+## Constraints
+
+- **Tech stack**: Kotlin 2.2.0, Android minSdk 21, OkHttp 5.x, Moshi 1.15.2
+- **Explicit API mode**: All public declarations must have visibility modifiers
+- **Thread model**: OkHttp interceptors are synchronous; uses `runBlocking` for token operations
+- **Git workflow**: Feature branches with PRs to `develop`; never commit directly to `develop`
+
+## Key Decisions
+
+| Decision | Rationale | Outcome |
+|----------|-----------|---------|
+| Result<T> over exceptions | Explicit error handling, forces callers to handle failures | ✓ Good |
+| Single-flight for token refresh | Prevents concurrent refresh storms, deduplicates network calls | ✓ Good |
+| Adaptive batching window | Balances latency vs throughput based on traffic patterns | ✓ Good |
+| StateFlow for connection state | Hot observable, immediate state for new collectors | ✓ Good |
+| runBlocking in interceptors | OkHttp constraint — interceptors are synchronous | ⚠️ Revisit (see CONCERNS.md) |
+
+---
+*Last updated: 2026-01-27 after initialization*

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -1,0 +1,31 @@
+# Project State
+
+## Current Position
+
+Phase: —
+Plan: —
+Status: Initialized (no active milestone)
+Last activity: 2026-01-27 — Project initialized
+
+## Project Reference
+
+See: .planning/PROJECT.md (updated 2026-01-27)
+
+**Core value:** Reliable real-time connectivity that automatically recovers from network disruptions and app lifecycle changes.
+**Current focus:** Ready for next milestone
+
+## Accumulated Context
+
+### Key Decisions
+- PR workflow: feature branches → PR to `develop`, never commit directly
+- Explicit API mode enforced via Kotlin compiler
+- Result<T> for all error handling
+
+### Known Issues
+- See .planning/codebase/CONCERNS.md for technical debt items
+
+### Blockers
+(None)
+
+---
+*State initialized: 2026-01-27*

--- a/.planning/codebase/ARCHITECTURE.md
+++ b/.planning/codebase/ARCHITECTURE.md
@@ -1,0 +1,235 @@
+# Architecture
+
+**Analysis Date:** 2026-01-26
+
+## Pattern Overview
+
+**Overall:** Layered client-server architecture with pluggable components for real-time connectivity.
+
+**Key Characteristics:**
+- Result-based error handling throughout (`Result<T>` instead of exceptions for expected failures)
+- Coroutine-based concurrency with structured coroutine scopes
+- Component lifecycle management via `StreamStartableComponent` interface
+- Composition over inheritance - most behavior provided via injected components
+- State Flow observables for reactive connection state and monitoring
+
+## Layers
+
+**API Layer (Public contracts):**
+- Purpose: Stable interfaces exposed to product SDKs (Chat, Video, Feeds)
+- Location: `stream-android-core/src/main/java/io/getstream/android/core/api/`
+- Contains: Interfaces, data classes, enums for public consumption
+- Depends on: Nothing - root dependencies
+- Used by: Internal implementations, product SDKs
+
+**Internal Implementation Layer:**
+- Purpose: Concrete implementations of API contracts, not exposed outside core
+- Location: `stream-android-core/src/main/java/io/getstream/android/core/internal/`
+- Contains: Impl classes, session management, event routing
+- Depends on: API layer, Android framework, OkHttp, Moshi, coroutines
+- Used by: Only used internally and via API layer
+
+**Model/Data Layer:**
+- Purpose: Data classes and value objects for messages, events, configuration
+- Location: `stream-android-core/src/main/java/io/getstream/android/core/api/model/` and `internal/model/`
+- Contains: Event types, connection state, errors, user data
+- Depends on: Nothing (clean data classes)
+- Used by: All layers
+
+**Socket/Network Layer:**
+- Purpose: WebSocket management, HTTP interceptor chain, network/lifecycle monitoring
+- Location: `stream-android-core/src/main/java/io/getstream/android/core/internal/socket/`, `internal/http/`
+- Contains: Socket session, WebSocket wrapper, health monitor, interceptors
+- Depends on: OkHttp, API models, serialization
+- Used by: Client implementation
+
+**Processing/Concurrency Layer:**
+- Purpose: Backpressure management, deduplication, batching, retries
+- Location: `stream-android-core/src/main/java/io/getstream/android/core/internal/processing/`
+- Contains: Single-flight processor, serial queue, batcher, retry processor
+- Depends on: Coroutines, logging
+- Used by: Client, socket session, authentication
+
+## Data Flow
+
+**Connection Sequence:**
+
+1. **User initiates connect** → `StreamClient.connect()` called
+2. **Single-flight deduplication** → `StreamSingleFlightProcessor` ensures only one concurrent connection attempt
+3. **Socket opening** → `StreamSocketSession.connect()` opens WebSocket via `StreamWebSocketFactory`
+4. **State: Opening** → Connection state transitions to `Connecting.Opening(userId)`
+5. **HTTP 101 response** → WebSocket handshake succeeds
+6. **State: Authenticating** → Connection state transitions to `Connecting.Authenticating(userId)`
+7. **Auth message sent** → `StreamWSAuthMessageRequest` with JWT from `StreamTokenManager` sent to server
+8. **Success response** → Server responds with `StreamClientConnectedEvent` (type: "connection.ok")
+9. **State: Connected** → Connection state transitions to `Connected(connectedUser, connectionId)`
+10. **Lifecycle observers start** → Health monitor begins periodic checks, socket session begins listening for events
+
+**Event Processing Pipeline:**
+
+1. **Socket receives message** → `StreamWebSocketListener.onMessage(text)`
+2. **Batcher queues** → Message offered to `StreamBatcher` for buffering/coalescing
+3. **Batch flush** → When batch full (10 items) or timeout (100ms-1s adaptive), messages flushed
+4. **Event parser** → `StreamCompositeEventSerializationImpl` routes by "type" field to core/product deserializers
+5. **Core event handling** → Internal events (connection.ok, health.check) processed locally
+6. **Product event delivery** → Non-core events delivered via `subscriptionManager.forEach { it.onEvent(...) }`
+7. **Client listener dispatch** → All registered `StreamClientListener` instances notified
+
+**Reconnection Flow:**
+
+1. **State trigger** → Network lost OR app backgrounded OR health check timeout
+2. **Recovery evaluation** → `StreamConnectionRecoveryEvaluator` checks if reconnect should occur
+3. **Automatic reconnect** → If connected AND (network recovered OR app resumed), connect again
+4. **Watch reestablishment** → `StreamWatcher<T>` notifies all rewatch listeners with full registry
+5. **Product re-watches** → Product SDKs re-establish server-side watches via callback
+
+**Token Refresh Flow:**
+
+1. **Token needed** → `StreamAuthInterceptor` detects missing/expired token
+2. **Load or refresh** → `StreamTokenManager` fetches from `TokenProvider` or refreshes existing
+3. **Single-flight dedup** → Multiple concurrent requests share same token refresh via single-flight processor
+4. **Retry with new token** → HTTP request retried with new Authorization header
+5. **Token error codes** → Codes 40 (invalid), 41 (expired), 42 (revoked) trigger refresh
+
+**State Management:**
+
+- **Connection state**: `MutableStateFlow<StreamConnectionState>` - single source of truth
+- **Network/Lifecycle state**: Observed separately, aggregated for recovery decisions
+- **Health check**: 25-second intervals with 60-second timeout for liveness detection
+- **Events flow**: Via `subscriptionManager` to all registered `StreamClientListener` instances
+
+## Key Abstractions
+
+**StreamClient (Facade):**
+- Purpose: Main entry point for connection lifecycle
+- Examples: `stream-android-core/src/main/java/io/getstream/android/core/api/StreamClient.kt`
+- Pattern: Factory function with dependency injection, wraps internal `StreamClientImpl`
+- Responsibilities: Expose `connect()`, `disconnect()`, `connectionState` StateFlow
+
+**StreamSocketSession (Coordinator):**
+- Purpose: Manages WebSocket lifecycle, authentication, event batching and routing
+- Examples: `stream-android-core/src/main/java/io/getstream/android/core/internal/socket/StreamSocketSession.kt`
+- Pattern: Holds references to socket, health monitor, batcher, event parser
+- Responsibilities: Socket lifecycle, handshake flow, event distribution
+
+**StreamSingleFlightProcessor (Deduplication):**
+- Purpose: Prevents concurrent execution of same operation, deduplicates results
+- Examples: `stream-android-core/src/main/java/io/getstream/android/core/internal/processing/StreamSingleFlightProcessorImpl.kt`
+- Pattern: `ConcurrentHashMap<Key, Deferred<Result<T>>>` - multiple callers await same result
+- Responsibilities: Deduplicate token refreshes, connection attempts
+
+**StreamBatcher (Coalescing):**
+- Purpose: Buffer and batch high-frequency messages with adaptive window
+- Examples: `stream-android-core/src/main/java/io/getstream/android/core/internal/processing/StreamBatcherImpl.kt`
+- Pattern: Dedicated worker coroutine, channel-based queue with configurable size/timeout
+- Responsibilities: Accumulate messages, flush on size/timeout, double window if full
+
+**StreamSerialProcessingQueue (Ordered execution):**
+- Purpose: Execute suspend functions sequentially with backpressure support
+- Examples: `stream-android-core/src/main/java/io/getstream/android/core/internal/processing/StreamSerialProcessingQueueImpl.kt`
+- Pattern: Dedicated worker coroutine, inbox channel with CompletableDeferred replies
+- Responsibilities: FIFO execution, suspension on full queue, caller awaits completion
+
+**StreamTokenManager (Auth lifecycle):**
+- Purpose: Manage JWT tokens, cache, refresh on expiration, deduplicate concurrent refreshes
+- Examples: `stream-android-core/src/main/java/io/getstream/android/core/internal/authentication/StreamTokenManagerImpl.kt`
+- Pattern: Wraps `TokenProvider`, uses single-flight processor for deduplication
+- Responsibilities: Load initial token, refresh on error, cache result
+
+**StreamCompositeEventSerializationImpl (Event routing):**
+- Purpose: Deserialize WebSocket events and route to appropriate handlers
+- Examples: `stream-android-core/src/main/java/io/getstream/android/core/internal/serialization/StreamCompositeEventSerializationImpl.kt`
+- Pattern: Peeks "type" field, dispatches to core or product deserializers
+- Responsibilities: Parse JSON, route by type, return composite result with both core/product events
+
+**StreamWatcher<T> (Watch registry):**
+- Purpose: Maintain list of watched resources, trigger re-watches on reconnection
+- Examples: `stream-android-core/src/main/java/io/getstream/android/core/api/watcher/StreamWatcher.kt`, `internal/watcher/StreamWatcherImpl.kt`
+- Pattern: Generic type parameter allows watching any identifier type (String, custom classes)
+- Responsibilities: Add/remove watch entries, notify listeners on connection changes, observe connection state
+
+**StreamSubscriptionManager<T> (Listener registry):**
+- Purpose: Store listeners with multiple retention policies (strong/weak references)
+- Examples: `stream-android-core/src/main/java/io/getstream/android/core/api/subscribe/StreamSubscriptionManager.kt`
+- Pattern: `ConcurrentLinkedQueue` with optional weak reference support
+- Responsibilities: Add/remove listeners, broadcast events, garbage-collect weakly-held listeners
+
+## Entry Points
+
+**StreamClient Factory Function:**
+- Location: `stream-android-core/src/main/java/io/getstream/android/core/api/StreamClient.kt:210-385`
+- Triggers: Called by product SDKs to create client instance
+- Responsibilities: Wire all dependencies (socket, monitors, processors, serialization), create `StreamClientImpl`
+
+**StreamSocketSession.connect():**
+- Location: `stream-android-core/src/main/java/io/getstream/android/core/internal/socket/StreamSocketSession.kt:182-462` (from CLAUDE.md)
+- Triggers: Called by `StreamClientImpl.connect()` after single-flight check
+- Responsibilities: Open WebSocket, send auth message, handle auth response, start health monitor
+
+**Socket Message Listener:**
+- Location: `stream-android-core/src/main/java/io/getstream/android/core/internal/socket/StreamSocketSession.kt:82-120`
+- Triggers: On every WebSocket message received
+- Responsibilities: Acknowledge health check, batch message, detect failures
+
+**Health Monitor:**
+- Location: `stream-android-core/src/main/java/io/getstream/android/core/internal/socket/monitor/StreamHealthMonitorImpl.kt`
+- Triggers: Periodic (25s interval) after connection established
+- Responsibilities: Send health check requests, detect timeout after 60s without ack
+
+**Network/Lifecycle Monitors:**
+- Location: `stream-android-core/src/main/java/io/getstream/android/core/internal/observers/`
+- Triggers: On connectivity change or app lifecycle state change
+- Responsibilities: Notify recovery evaluator of state changes
+
+## Error Handling
+
+**Strategy:** Result-based error handling with explicit token error codes
+
+**Patterns:**
+
+1. **Expected failures** → Return `Result<T>` (failure branch contains error)
+   - Location: All public API methods
+   - Example: `client.connect()` returns `Result<StreamConnectedUser>`
+
+2. **Token errors** → Detect via error code (40, 41, 42) not HTTP status
+   - Location: `StreamAuthInterceptor.kt`, `StreamClientImpl.kt`
+   - Pattern: `onTokenError` extension method checks `StreamEndpointErrorData.code`
+
+3. **Socket errors** → Detected via listener callbacks (onFailure, onClosed)
+   - Location: `StreamSocketSession.kt:100-119`
+   - Pattern: Emit `Disconnected` state, cleanup resources
+
+4. **Batcher overflow** → Message drop with error callback
+   - Location: `StreamSocketSession.kt:88-94`
+   - Pattern: Call `disconnect(error)` to propagate failure
+
+5. **Health monitor timeout** → Disconnect with exception
+   - Location: `StreamHealthMonitorImpl.kt`
+   - Pattern: Emit `Disconnected` state with timeout exception
+
+## Cross-Cutting Concerns
+
+**Logging:** Lambda-based via `StreamLogger`
+- Strategy: Avoid expensive computations via lazy evaluation
+- Pattern: `logger.d { "message" }` only evaluated if DEBUG enabled
+- Location: Used throughout all components
+
+**Validation:** Input validation on public API boundaries
+- Strategy: Validate user data on `connect()`, reject invalid tokens
+- Pattern: Return `Result.failure` on invalid input
+
+**Authentication:** JWT-based via provider pattern
+- Strategy: Delegate token fetch to product SDK, cache locally
+- Pattern: `TokenProvider.getToken()` called on demand, single-flight deduplicated
+
+**Thread safety:** All public APIs are thread-safe
+- Strategy: Atomic flags, `ConcurrentHashMap`, coroutine-safe state flows
+- Pattern: No external synchronization needed for public method calls
+
+**Resource cleanup:** Proper disposal of sockets, monitors, subscriptions
+- Strategy: Idempotent cleanup guards via `AtomicBoolean`
+- Pattern: `disconnect()` is idempotent, subsequent calls are no-ops for listeners
+
+---
+
+*Architecture analysis: 2026-01-26*

--- a/.planning/codebase/CONCERNS.md
+++ b/.planning/codebase/CONCERNS.md
@@ -1,0 +1,466 @@
+# Codebase Concerns
+
+**Analysis Date:** 2026-01-26
+
+## Tech Debt
+
+### OkHttp Thread Pool Blocking (High Priority)
+
+**Issue:** `StreamAuthInterceptor` uses `runBlocking` to load and refresh tokens on OkHttp's synchronous HTTP thread.
+
+**Files:** `stream-android-core/src/main/java/io/getstream/android/core/internal/http/interceptor/StreamAuthInterceptor.kt:66-67, 91-92`
+
+**Impact:**
+- Token provider `loadToken()` and `refresh()` suspending functions block the OkHttp thread pool
+- Long-running token operations (network delays, slow provider implementations) freeze HTTP request processing
+- Multiple concurrent HTTP requests face cascading delays waiting for token availability
+- Potential for thread starvation if token provider is slow
+
+**Context:** OkHttp interceptors are inherently synchronous; retrofit/HTTP layer cannot use suspend functions. This is a fundamental architectural constraint (lines 44).
+
+**Fix Approach:**
+- Keep synchronous call sites as-is (unavoidable)
+- Add performance guidance in token provider contract: require `TokenProvider.loadToken()` to complete in <100ms
+- Implement token pre-refresh: call `tokenManager.refresh()` before token expiry via scheduled background task
+- Cache tokens aggressively to avoid blocking on load operations
+- Monitor token provider latency in production with metrics
+- Document that slow token providers directly degrade HTTP performance
+
+---
+
+### Uninitialized Property Risk in StreamWebSocketImpl
+
+**Issue:** `StreamWebSocketImpl` uses `lateinit var socket: WebSocket` initialized only in `open()` method.
+
+**Files:** `stream-android-core/src/main/java/io/getstream/android/core/internal/socket/StreamWebSocketImpl.kt:39`
+
+**Impact:**
+- Calling `send()` or `close()` before `open()` throws `UninitializedPropertyAccessException`
+- Runtime crash instead of graceful error
+- Tests may pass with mocked sockets but fail in production where initialization order matters
+
+**Current Mitigation:** `withSocket` helper checks `::socket.isInitialized` (line 135) with clear error message
+
+**Fix Approach:**
+- Add explicit validation in public methods: throw early with documented error message
+- Current implementation is defensive (lines 138-140); no immediate action required
+- Document initialization contract in `open()` docstring
+
+---
+
+### Nullable Field Assignment Without Synchronization
+
+**Issue:** `StreamHealthMonitorImpl.lastAck` is volatile-equivalent but assigned unsafely across threads.
+
+**Files:** `stream-android-core/src/main/java/io/getstream/android/core/internal/socket/monitor/StreamHealthMonitorImpl.kt:52, 67`
+
+**Impact:**
+- Race condition if `acknowledgeHeartbeat()` (line 67) called from OkHttp WebSocket thread while `start()` runs health check logic on scope thread
+- Lost heartbeat acknowledgment, falsely triggering liveness threshold
+- Stale `lastAck` value causing premature socket disconnection
+
+**Current Behavior:** Simple `Long` assignment is atomic on JVM, but memory visibility not guaranteed across threads without volatile
+
+**Fix Approach:**
+- Declare `lastAck` as `AtomicLong` instead of plain `Long`
+- Use `AtomicLong.getAndSet()` in `acknowledgeHeartbeat()` for true atomicity with visibility guarantee
+- Match pattern used in `StreamSocketSession` (lines 68, 71)
+
+---
+
+## Known Bugs
+
+### Race Condition in StreamSocketSession Message Handling
+
+**Issue:** No guaranteed ordering when both `onMessage` callbacks (eventListener and temporary handshakeListener) receive same frame from WebSocket.
+
+**Files:**
+- `stream-android-core/src/main/java/io/getstream/android/core/internal/socket/StreamSocketSession.kt:82-120` (persistent listener)
+- `stream-android-core/src/main/java/io/getstream/android/core/internal/socket/StreamSocketSession.kt:369-415` (handshake listener)
+
+**Trigger:** WebSocket message arrives while both listeners are subscribed (lines 314, 444).
+
+**Impact:**
+- Message processed by temporary handshake listener first (priority unclear)
+- If batch processing in `eventListener` causes async processing, state becomes inconsistent
+- Connection success callback may not execute if handshake listener consumes message first
+
+**Symptoms:**
+- Sporadic connect failures on high-latency networks
+- Flaky tests under concurrent WebSocket events
+
+**Workaround:** Temporary listeners explicitly cancel before permanent ones take over (line 286)
+
+**Fix Approach:**
+- Replace subscription model with explicit handshake state machine
+- Reject incoming messages during handshake phase until connection completes
+- Add message ordering guarantee in subscription manager or use sequential listener dispatch
+
+---
+
+### Missing Error Handling in Batcher Message Drop
+
+**Issue:** When `batcher.offer()` fails (channel full), socket disconnects but no detailed logging of buffer state.
+
+**Files:** `stream-android-core/src/main/java/io/getstream/android/core/internal/socket/StreamSocketSession.kt:87-94`
+
+**Impact:**
+- Server sends rapid event burst; batch buffer capacity exceeded
+- Socket silently disconnects with generic "Message dropped" error
+- No visibility into which messages were lost or why buffer is full
+- Difficult to diagnose production issues related to high-frequency events
+
+**Current Behavior:** Logs message content but not buffer size, pending job count, or heap pressure
+
+**Fix Approach:**
+- Log buffer fill percentage and pending batch size before disconnect
+- Add metrics/counters for drop events
+- Increase default `channelCapacity` if burst handling inadequate
+- Consider circuit breaker pattern: slow down message processing instead of dropping
+
+---
+
+## Security Considerations
+
+### Token Serialization in Logs (Medium Risk)
+
+**Issue:** Token values appear in debug/verbose logs when serializing authentication requests.
+
+**Files:**
+- `stream-android-core/src/main/java/io/getstream/android/core/internal/socket/StreamSocketSession.kt:348` (auth request)
+- `stream-android-core/src/main/java/io/getstream/android/core/internal/client/StreamClientImpl.kt:194` (token error)
+
+**Impact:**
+- Debug logs containing full JWT tokens could be exposed in crash reports, monitoring systems, or device logs
+- Token replay attack risk if logs are captured/exfiltrated
+- Compliance issue: tokens should never appear in plaintext logs
+
+**Current Mitigation:** Uses lambda-based logging (`{ "..." }`) which only executes when log level enabled; still risky at DEBUG level
+
+**Recommendations:**
+- Implement token redaction utility: replace full token with `<token_hash>` in serialization
+- Mark `StreamToken` data class with custom `toString()` that redacts value
+- Add pre-commit hook to flag token-related debug logs
+- Disable verbose socket logging in production builds
+
+---
+
+### Connection ID Holder Race Condition
+
+**Issue:** `StreamConnectionIdHolder` may have unsynchronized access during rapid connect/disconnect cycles.
+
+**Files:** `stream-android-core/src/main/java/io/getstream/android/core/api/socket/StreamConnectionIdHolder.kt`
+
+**Impact:**
+- Race between `setConnectionId()` (line 146 in StreamClientImpl) and `clear()` (line 163)
+- Stale connection ID leaks into subsequent HTTP requests via interceptor
+- Security: requests authenticated to wrong connection context
+- User A's requests may be processed in User B's connection context
+
+**Current Protection:** Atomic operations (AtomicReference), but compound operations not atomic
+
+**Fix Approach:**
+- Wrap compound operations in synchronized block: `setConnectionId()` + `clear()` both acquire same lock
+- Ensure interceptor reads connection ID safely with consistent snapshot
+- Add test: concurrent set/clear/get operations verify final state consistency
+
+---
+
+## Performance Bottlenecks
+
+### Adaptive Window Backoff May Cause Cascading Delays
+
+**Issue:** `StreamBatcher` doubles delay window on full batch, potentially causing 1s+ delays in high-traffic scenarios.
+
+**Files:** `stream-android-core/src/main/java/io/getstream/android/core/internal/processing/StreamBatcherImpl.kt:120-126`
+
+**Impact:**
+- Server sends 10+ events per batch
+- Window doubles: 100ms → 200ms → 400ms → 1000ms (max)
+- Realtime features feel sluggish during burst traffic
+- User perceives lag in chat message appearance, notification delivery
+
+**Current Values:** `initialDelayMs=100, maxDelayMs=1000` (lines 31-33, config in CLAUDE.md)
+
+**Scenario:** Mobile app reconnects after losing network; server queues 100 events; batches process slowly due to backoff
+
+**Fix Approach:**
+- Reduce `maxDelayMs` to 500ms for chat/messaging workloads
+- Add exponential fallback: if traffic sustained, cap at lower threshold
+- Profile typical event frequencies; tune window to match expected patterns
+- Consider predictive backoff: ramp up based on event velocity, not just batch full status
+
+---
+
+### Health Monitor Check Granularity
+
+**Issue:** Health check every 25s with 60s timeout means 35s window for detecting dead connections.
+
+**Files:** `stream-android-core/src/main/java/io/getstream/android/core/internal/socket/monitor/StreamHealthMonitorImpl.kt:47-48`
+
+**Impact:**
+- Dead socket (server-side) not detected for up to 60+ seconds
+- Users see frozen UI during this window
+- Production: significant negative impact on perceived app reliability
+
+**Trade-off:** More frequent checks increase battery/bandwidth; less frequent increases stale connection window
+
+**Fix Approach:**
+- Consider 10s health checks with 30s timeout for critical realtime features
+- Make configurable: allow SDKs to tune for their latency tolerance
+- Add jitter to health checks: prevent thundering herd on reconnect
+
+---
+
+## Fragile Areas
+
+### Token Manager Refresh Deduplication
+
+**Issue:** Token refresh relies on `StreamSingleFlightProcessor` for deduplication. If processor is cleared/restarted unexpectedly, multiple concurrent refreshes may occur.
+
+**Files:**
+- `stream-android-core/src/main/java/io/getstream/android/core/internal/authentication/StreamTokenManagerImpl.kt:58-63`
+- `stream-android-core/src/main/java/io/getstream/android/core/internal/processing/StreamSingleFlightProcessorImpl.kt:41-82`
+
+**Fragility:** `StreamClientImpl.disconnect()` calls `singleFlight.clear(true)` (line 172), which clears the processor. If `refresh()` is in-flight, continuation is abandoned.
+
+**Impact:**
+- Token provider called multiple times for same refresh
+- Backend may rate-limit token endpoint
+- Cascade: rate limit leads to connect failure
+
+**Safe Modification:**
+- Never clear processor while token refresh in-flight
+- Check `singleFlight.has(refreshKey)` before clearing
+- Add timeout to token refresh: fail instead of hanging forever
+
+---
+
+### Socket Session Cleanup Idempotency
+
+**Issue:** `cleanup()` uses `AtomicBoolean` to guard idempotent shutdown, but `disconnect()` called again after cleanup may not notify listeners properly.
+
+**Files:** `stream-android-core/src/main/java/io/getstream/android/core/internal/socket/StreamSocketSession.kt:464-474`
+
+**Impact:**
+- First `disconnect()` calls `notifyState(Disconnected)` via `closingByUs` guard (line 147)
+- Second `disconnect()` skips state notification (already set)
+- Listeners don't receive final cleanup signal
+- Resource leaks: subscriptions not cancelled if already cleaned
+
+**Safe Modification:**
+- Document that `disconnect()` is idempotent for state, but socket close attempted every time
+- Add explicit comment: "listener notification only on first call"
+- Test concurrent `disconnect()` calls verify single notification
+
+---
+
+## Scaling Limits
+
+### Message Batch Buffer Size
+
+**Current Capacity:** `Channel.UNLIMITED` default for batcher inbox (line 35 in StreamBatcherImpl)
+
+**Limit Scenario:**
+- Server sends 10,000 events in rapid succession
+- Each event 1KB → 10MB buffered in memory
+- On memory-constrained devices (low-end Android), OutOfMemoryError
+- Buffer never cleared if consumer paused/blocked
+
+**Impact:** High-end devices + heavy usage (video calls with many participants) can hit memory ceiling
+
+**Fix Approach:**
+- Change default to `Channel.BUFFERED` (65-item buffer)
+- Provide configurable `channelCapacity` parameter for SDKs
+- Add backpressure: slow consumer signals upstream, prevents accept at source
+- Monitor buffer depth; log warnings at 80%/90% thresholds
+
+---
+
+### Network Monitor Callback Dispatch
+
+**Issue:** `StreamNetworkAndLifeCycleMonitor` dispatches state changes synchronously to all listeners.
+
+**Files:** `stream-android-core/src/main/java/io/getstream/android/core/internal/observers/StreamNetworkAndLifecycleMonitorListener.kt`
+
+**Impact:**
+- One slow listener blocks all others from receiving network state
+- Example: SDKs with heavy recovery logic block network monitor callbacks
+- Cascading effect: app-wide UI freezes during network transitions
+
+**Fix Approach:**
+- Dispatch to listeners asynchronously (launch on scope)
+- Add timeout: cancel listener callback after 5s, log warning
+- Profile typical listener callback time; set SLA expectations
+
+---
+
+## Test Coverage Gaps
+
+### StreamClientImpl Integration Testing
+
+**Files:** `stream-android-core/src/main/java/io/getstream/android/core/internal/client/StreamClientImpl.kt`
+
+**What's Not Tested:**
+- Full connect → disconnect → reconnect cycle with network/lifecycle state changes
+- Token refresh during in-flight connect (lines 193-200)
+- Race between `connect()` and `disconnect()` via single-flight processor
+- Recovery effect execution with concurrent state changes (lines 203-241)
+
+**Risk:** Medium - Core client logic may have race conditions not caught by unit tests
+
+**Recommendation:**
+- Add integration test: simulate network loss during authentication
+- Add stress test: rapid connect/disconnect/recover cycles (50+ iterations)
+- Use `TestDispatchers` to control timing and expose race conditions
+
+---
+
+### StreamSocketSession Authentication Handshake
+
+**Files:** `stream-android-core/src/main/java/io/getstream/android/core/internal/socket/StreamSocketSession.kt:182-462`
+
+**What's Not Tested:**
+- WebSocket closes during authentication (onClosed callback while Authenticating state)
+- Message arrives after handshake timeout but before cancellation
+- Connection success followed by immediate server error event
+- Health check callback throws exception (lines 211-228)
+
+**Risk:** High - Complex state machine with timing-dependent behavior
+
+**Recommendation:**
+- Test: WebSocket closes during Authenticating state → verify Disconnected emitted with cause
+- Test: Delayed auth response → verify timeout handling
+- Test: Health check callback exception → verify monitor continues monitoring
+
+---
+
+### Network/Lifecycle Monitor Snapshot Atomicity
+
+**Files:** `stream-android-core/src/main/java/io/getstream/android/core/internal/observers/`
+
+**What's Not Tested:**
+- Rapid network state → background → foreground transitions
+- Snapshot consistency: network state + lifecycle state read atomically (lines 121-127 in StreamClientImpl)
+- Recovery evaluator called with stale snapshot due to race
+
+**Risk:** Medium - Loss of network events or stale recovery decisions
+
+---
+
+## Missing Critical Features
+
+### No Circuit Breaker for Failed Reconnects
+
+**Current Behavior:** Auto-reconnects infinitely on network loss; no exponential backoff or max retry limits.
+
+**Files:** `stream-android-core/src/main/java/io/getstream/android/core/internal/recovery/StreamConnectionRecoveryEvaluatorImpl.kt`
+
+**Impact:**
+- Server maintains dead socket connections from app crashing
+- Battery drain: app repeatedly attempts connect while offline
+- Network congestion during mass outage: 1M users all retrying simultaneously
+
+**Fix Approach:**
+- Implement exponential backoff with jitter for reconnect attempts
+- Add max retry limit before requiring user action
+- Emit `Disconnected(RECONNECT_FAILED_PERMANENTLY)` after threshold exceeded
+- Document recovery behavior for SDK consumers
+
+---
+
+### No Request Deduplication at HTTP Layer
+
+**Current State:** OkHttp interceptors handle individual requests; no request coalescing or caching for identical API calls.
+
+**Impact:**
+- Rapid API calls for same resource (e.g., list channels) generate multiple identical HTTP requests
+- Network waste, server load spike, battery drain
+- Each request blocks on token refresh if token expired
+
+**Fix Approach:**
+- Add HTTP cache (OkHttp CacheControl headers)
+- Implement request coalescing: multiple identical requests awaits single response
+- Add ETags/conditional request support for API endpoints
+
+---
+
+## Dependencies at Risk
+
+### OkHttp Version Constraint
+
+**Risk:** If OkHttp is pinned to old version, security patches unavailable.
+
+**Files:** Check `stream-android-core/build.gradle.kts` for `okhttp` version constraint
+
+**Typical Issue:** OkHttp 3.x → 4.x migration breaks interceptor API (synchronous → async patterns)
+
+**Recommendation:**
+- Pin to latest stable 4.x version (supports modern Android)
+- Document required OkHttp version for consumers
+- Use version range with upper bound: `"com.squareup.okhttp3:okhttp:4.+"` with max specified
+
+---
+
+### Moshi KSP Code Generation
+
+**Risk:** KSP code generation may be incomplete if adapters not found at compile time.
+
+**Files:** `stream-android-core/build.gradle.kts` (KSP plugin config)
+
+**Impact:**
+- Missing adapter → runtime `JsonAdapter` not found exception
+- Silent failures if type isn't annotated with `@JsonClass(generateAdapter = true)`
+
+**Recommendation:**
+- Verify all `@JsonClass` data classes are present in main source (not in generated code)
+- Add lint rule: ensure all serializable types have annotation
+- Test round-trip serialization for critical event types
+
+---
+
+## Architecture Debt
+
+### Event Subscription Model Complexity
+
+**Issue:** Multiple subscription managers + composite serialization creates hard-to-trace event routing.
+
+**Files:**
+- `stream-android-core/src/main/java/io/getstream/android/core/internal/serialization/StreamCompositeEventSerializationImpl.kt:98-125` (routing logic)
+- `stream-android-core/src/main/java/io/getstream/android/core/internal/socket/StreamSocketSession.kt:256-262` (listener dispatch)
+
+**Impact:**
+- Event reaches wrong listener type (core vs product)
+- Difficult to debug: trace event through composite serialization → peekType → route → deserialize
+- Health check events filtered late (line 258) instead of early in deserialization
+
+**Fix Approach:**
+- Simplify to single event type with tagged union (sealed class)
+- Route in serializer, not after deserialization
+- Eliminate health check filtering; wrap in dummy event type
+
+---
+
+## Known Limitations
+
+### No Built-in Request Retry for Network Errors
+
+**Current:** HTTP interceptors handle token errors; generic network errors not retried.
+
+**Impact:** Transient network failures fail fast instead of auto-retry
+
+**Recommendation:** Product SDKs implement own retry logic using `StreamRetryPolicy` for non-token errors
+
+---
+
+### No Connection State Prediction
+
+**Current:** No indication of upcoming state changes (e.g., "will reconnect in 5s")
+
+**Impact:** UI can't show "reconnecting" state smoothly; sudden transitions confuse users
+
+**Recommendation:** Emit intermediate states (e.g., `Disconnected.Reconnecting(delay)`) if reconnect scheduled
+
+---
+
+*Concerns audit: 2026-01-26*

--- a/.planning/codebase/CONVENTIONS.md
+++ b/.planning/codebase/CONVENTIONS.md
@@ -1,0 +1,246 @@
+# Coding Conventions
+
+**Analysis Date:** 2026-01-26
+
+## Naming Patterns
+
+**Files:**
+- Implementation files: `<Name>Impl.kt` (e.g., `StreamClientImpl.kt`, `StreamWatcherImpl.kt`)
+- Test files: `<ClassUnderTest>Test.kt` (e.g., `StreamRetryProcessorImplTest.kt`, `StreamWatcherImplTest.kt`)
+- Model/data classes: `Stream<Entity>.kt` (e.g., `StreamConnectionState.kt`, `StreamConnectedUser.kt`)
+- Interface/contract files: `Stream<Contract>.kt` (e.g., `StreamWatcher.kt`, `StreamLogger.kt`)
+
+**Functions:**
+- `camelCase` for all functions and methods
+- Function names must be at least 2 characters, at most 30 characters
+- Suspend functions follow standard camelCase: `suspend fun connect(...)`
+
+**Variables:**
+- `camelCase` for local variables and parameters
+- Private variables: `_privateVar` or `privateVar` (with underscore optional)
+- Boolean properties: Must start with `is`, `has`, or `are` (e.g., `isActive`, `hasError`)
+
+**Types:**
+- `PascalCase` for classes, interfaces, data classes, enums
+- Example: `StreamRetryPolicy`, `StreamConnectionState`, `StreamWatcher<T>`
+
+**Packages:**
+- Lowercase with dots: `io.getstream.android.core.<feature>`
+- Must start with `io.getstream` per detekt rule
+
+## Code Style
+
+**Formatting:**
+- Tool: Detekt with formatting rules enabled (`autoCorrect: true`)
+- Run: `./gradlew spotlessApply` (uses ktfmt internally)
+- Max line length: **140 characters** (configured in detekt.yml)
+- Indentation: 4 spaces (checked via `NoTabs` rule)
+
+**Linting:**
+- Tool: Detekt (static analysis)
+- Run: `./gradlew detekt` (auto-corrects issues)
+- Configuration: `config/detekt/detekt.yml`
+- Warnings treated as errors: `warningsAsErrors: true` (detekt level 4)
+- Android lint: `abortOnError: true`, `warningsAsErrors: true` (in `lint.xml`)
+
+**Key Detekt Rules:**
+- `BracesOnIfStatements`: Always require braces, single-line and multi-line
+- `BracesOnWhenStatements`: Never on single-line, always on multi-line
+- `DataClassShouldBeImmutable`: Data classes must be immutable
+- `MaxLineLength`: 140 character limit (code lines, not imports/comments)
+- `FunctionMaxLength`: Function names limited to 30 characters
+- `CyclomaticComplexMethod`: Threshold of 8 (ignores simple when entries)
+- `LongMethod`: Threshold of 80 lines
+- `LongParameterList`: 7 parameters max for functions/constructors
+
+## Import Organization
+
+**Order:**
+1. Kotlin standard library imports (`kotlin.*`, `kotlinx.*`)
+2. Java/Android imports (`java.*`, `android.*`, `androidx.*`)
+3. Third-party library imports (`io.getstream.*`, `com.squareup.*`, etc.)
+4. Internal project imports (relative package imports)
+
+**Path Aliases:**
+- Not used; full qualified imports required per configuration
+- Detekt rule `WildcardImport` is enabled - no wildcard imports in regular code
+- Exception: Test files allow wildcard for some stdlib imports in practice
+
+**Forbidden Imports:**
+- No `java.lang.SuppressWarnings` - use `@Suppress` instead
+- No `java.lang.Deprecated` - use `@Deprecated` instead
+- No `println()` or `print()` - use logger instead
+
+## Error Handling
+
+**Pattern: Result-Based Returns**
+- All public APIs return `Result<T>` instead of throwing
+- Location: `stream-android-core/src/main/java/io/getstream/android/core/api/utils/Result.kt`
+
+```kotlin
+// Extension for monadic chaining
+fun <T, R> Result<T>.flatMap(transform: (T) -> Result<R>): Result<R> =
+    fold(onSuccess = { transform(it) }, onFailure = { Result.failure(it) })
+
+// Observe success/failure
+result.onSuccess { value -> ... }
+result.onFailure { error -> ... }
+result.fold(onSuccess = { ... }, onFailure = { ... })
+```
+
+**CancellationException Handling**
+- CancellationException **must be rethrown**, not captured in Result
+- Use `runCatchingCancellable` utility for proper semantics
+- Location: `stream-android-core/src/main/java/io/getstream/android/core/api/utils/Catching.kt`
+
+```kotlin
+public inline fun <T> runCatchingCancellable(block: () -> T): Result<T> {
+    return try {
+        Result.success(block())
+    } catch (ce: CancellationException) {
+        throw ce  // Rethrow immediately
+    } catch (t: Throwable) {
+        Result.failure(t)
+    }
+}
+```
+
+**Exception Types**
+- Custom exceptions inherit from standard types with proper context
+- Location: `stream-android-core/src/main/java/io/getstream/android/core/api/model/exceptions/`
+- Always provide message and cause for exceptions per detekt rule
+
+## Logging
+
+**Framework:** Lambda-based `StreamLogger` interface
+- Location: `stream-android-core/src/main/java/io/getstream/android/core/api/log/StreamLogger.kt`
+
+**Patterns:**
+- Use lambda parameters to defer string computation: `logger.d { "message" }`
+- Level methods: `d()`, `i()`, `w()`, `e()`, `v()`
+- Error logging with exception: `logger.e(throwable) { "context message" }`
+
+```kotlin
+// Good: Lambda defers computation until log level check passes
+logger.v { "Expensive: ${expensiveComputation()}" }
+
+// Bad: String always computed
+logger.d("String: " + expensiveComputation())
+```
+
+**Levels:**
+- **Verbose** (1): Detailed debugging, low-level flow
+- **Debug** (2): General debugging information
+- **Info** (3): Normal operation milestones
+- **Warning** (4): Non-fatal issues, recoverable conditions
+- **Error** (5): Recoverable failures, exceptions caught
+
+**Common Patterns:**
+- Connection state changes: Log at Verbose level
+- Retry attempts: Log at Verbose with attempt number
+- Listener errors: Log at Verbose with error context
+- Component lifecycle: Log at Debug level
+
+## Comments
+
+**When to Comment:**
+- Public APIs require KDoc (checked by detekt `UndocumentedPublicClass`, `UndocumentedPublicFunction`)
+- Complex algorithms: Explain non-obvious logic
+- Non-obvious parameter names: Document expectations
+- Invariants: Document assumptions about state
+
+**JSDoc/KDoc:**
+- Required for all public classes and functions
+- Required for public properties
+- Excluded in test files (per detekt config)
+
+```kotlin
+/**
+ * Manages watched resources and triggers re-watching on connection state changes.
+ *
+ * @param scope Coroutine scope for async operations
+ * @param connectionState StateFlow providing connection state updates
+ * @param watched Registry of watched entries
+ * @param rewatchSubscriptions Subscription manager for rewatch listeners
+ * @param logger Logger for diagnostics
+ */
+internal class StreamWatcherImpl<T>(
+    private val scope: CoroutineScope,
+    private val connectionState: StateFlow<StreamConnectionState>,
+    ...
+)
+```
+
+**Forbidden Comments:**
+- `TODO:` - Forbidden by detekt rule `ForbiddenComment`
+- `FIXME:` - Forbidden by detekt rule `ForbiddenComment`
+- `STOPSHIP:` - Forbidden by detekt rule `ForbiddenComment`
+
+## Function Design
+
+**Size Guidelines:**
+- Max 80 lines per function (detekt `LongMethod` rule)
+- Prefer small focused functions for testability
+- Early returns preferred for guard clauses
+
+**Parameters:**
+- Max 7 parameters for functions and constructors (detekt rule)
+- Use named arguments when calling functions with 3+ parameters
+- Constructor parameters may be annotated with detekt rule `ConstructorParameterNaming`
+
+**Return Values:**
+- Single return statement preferred (detekt `ReturnCount` max: 1)
+- Exception: Excludes `equals` method and guard clauses
+- Return from lambda: OK (excludeReturnFromLambda: true)
+
+## Module Design
+
+**Exports:**
+- Internal APIs marked with `@StreamInternalApi` annotation
+- Published APIs marked with `@StreamPublishedApi` annotation
+- Delicate APIs marked with `@StreamDelicateApi` annotation
+- All public declarations must have visibility modifier (explicit API enabled)
+
+**Barrel Files:**
+- Factory functions in interface files (e.g., `StreamWatcher.kt` contains the factory)
+- Implementation suffix pattern: `StreamWatcher` interface with `StreamWatcherImpl` implementation
+
+**Visibility:**
+- `public` for published APIs (SDK-exposed)
+- `internal` for internal infrastructure
+- `private` for private helpers within class/file
+
+## Special Patterns
+
+**Data Classes:**
+- Must use `@JsonClass(generateAdapter = true)` for Moshi serialization
+- Moshi adapters generated via KSP at compile time
+- Keep immutable (all properties `val`)
+- Location: `stream-android-core/src/main/java/io/getstream/android/core/api/model/`
+
+```kotlin
+@JsonClass(generateAdapter = true)
+data class MyEvent(
+    val type: String,
+    val data: String,
+    val timestamp: Date
+)
+```
+
+**Sealed Classes for Polymorphism:**
+- Used for state machines and union types
+- Example: `StreamConnectionState` (Idle, Connecting, Connected, Disconnected)
+- Detekt enforces exhaustive when expressions: `checkExhaustiveness: true`
+
+**Extension Functions:**
+- Placed in dedicated utility files matching their receiver type
+- Convention: `<Receiver>Extensions.kt` or `<Feature>.kt`
+- Examples: `Flows.kt`, `Result.kt`, `Catching.kt`
+
+**Atomic Operations:**
+- Use `AtomicBoolean`, `AtomicInteger`, `AtomicReference` for thread-safe flags
+- Example: `AtomicBoolean(false)` with `compareAndSet()` for idempotency guards
+
+---
+
+*Convention analysis: 2026-01-26*

--- a/.planning/codebase/INTEGRATIONS.md
+++ b/.planning/codebase/INTEGRATIONS.md
@@ -1,0 +1,219 @@
+# External Integrations
+
+**Analysis Date:** 2026-01-26
+
+## APIs & External Services
+
+**Stream Backend (Primary):**
+- Stream WebSocket API - Real-time connection for chat, feeds, video
+  - SDK/Client: OkHttp 5.1.0 WebSocket client
+  - Auth: JWT token via `StreamTokenProvider` interface
+  - Location: `stream-android-core/src/main/java/io/getstream/android/core/internal/socket/factory/StreamWebSocketFactoryImpl.kt`
+
+**REST API (Optional):**
+- HTTP REST endpoints via Retrofit 3.0.0
+  - SDK/Client: Retrofit with OkHttp backend
+  - Auth: JWT Authorization header
+  - Location: Managed via `StreamHttpConfig` and interceptors
+
+## Data Storage
+
+**Databases:**
+- None - Library has NO persistent database integration
+- Token caching: In-memory only (StateFlow in `StreamTokenManagerImpl.kt`)
+- No Room, Realm, or SQLite integration
+
+**File Storage:**
+- None - No file system integration
+- No local file caching or persistence
+
+**Caching:**
+- In-memory token cache: `cachedToken: MutableStateFlow<StreamToken?>` in `StreamTokenManagerImpl.kt`
+- HTTP client configuration supports OkHttp cache layer (consumer app configures)
+- Message batching cache: `StreamBatcher` (10 items, in-memory)
+- Rewatch registry: `ConcurrentHashMap` in `StreamWatcherImpl.kt` (in-memory)
+
+## Authentication & Identity
+
+**Auth Provider:**
+- Custom implementation required by consumer
+  - Interface: `StreamTokenProvider` located at `stream-android-core/src/main/java/io/getstream/android/core/api/authentication/StreamTokenProvider.kt`
+  - Contract: Implement `suspend fun loadToken(userId: StreamUserId): StreamToken`
+  - Responsibility: Network call to consumer's auth backend to mint JWT tokens
+  - Never embed secrets on-device; token creation/rotation must happen on server
+
+**Token Management:**
+- Implementation: `StreamTokenManagerImpl.kt`
+- Single-flight pattern: Deduplicates concurrent refresh requests
+- Invalidation on error codes: 40 (invalid signature), 41 (expired), 42 (revoked)
+- Caching strategy: Caches first token, invalidates on error, refreshes on demand
+- Interceptor integration: `StreamAuthInterceptor` handles token refresh in HTTP layer
+
+**WebSocket Authentication Flow:**
+1. Opens WebSocket with API key: `?api_key=<key>&stream-auth-type=jwt`
+2. Receives HTTP 101 upgrade response
+3. Sends `StreamWSAuthMessageRequest` with JWT token and user details
+4. Receives `StreamClientConnectedEvent` (type: "connection.ok") on success
+5. Receives `StreamClientConnectionErrorEvent` (type: "connection.error") on failure
+
+## Monitoring & Observability
+
+**Error Tracking:**
+- None - Library provides no built-in error tracking integration (Sentry, Firebase Crashlytics, etc.)
+- Consumer app responsible for integrating error tracking
+- Errors surfaced as: `Result<T>` return types with `Throwable` in failure case
+- API errors: `StreamEndpointException` wraps backend error responses
+
+**Logs:**
+- Approach: Custom logger interface via `StreamLogger` and `StreamLoggerProvider`
+- Default implementation: Android `Log` class (LogCat)
+- Configuration: `StreamLoggerProvider.defaultAndroidLogger()` factory
+- Log levels: Verbose, Debug, Info, Warning, Error
+- Chunking: Logs split if exceeding 4000 characters (LogCat limit)
+- Location: `stream-android-core/src/main/java/io/getstream/android/core/api/log/`
+
+**Health Monitoring:**
+- Internal: `StreamHealthMonitor` - Periodic heartbeat (25s interval, 60s timeout)
+- Connection state: `connectionState: StateFlow<StreamConnectionState>` (hot state flow)
+- Network state: `StreamNetworkMonitor` observes `ConnectivityManager` callbacks
+- Lifecycle state: `StreamLifecycleMonitor` observes app background/foreground via `ProcessLifecycleOwner`
+
+## CI/CD & Deployment
+
+**Hosting:**
+- None configured - Library for integration into Android applications
+- Stream backend: Consumer app connects to Stream cloud services
+
+**CI Pipeline:**
+- Detekt configured for auto-correcting code quality issues
+- Spotless for code formatting (ktfmt)
+- Tests run via Gradle: `./gradlew :stream-android-core:test`
+- Lint checks enforced: `abortOnError = true, warningsAsErrors = true`
+
+**Publishing:**
+- Maven Central publishing via stream-conventions plugin
+- Repository: `stream-core-android`
+- Uses `com.vanniktech.maven.publish` for publishing configuration
+- Requires: Maven signing credentials for publish
+
+## Environment Configuration
+
+**Required env vars:**
+- None configured at library level
+- Consumer app must provide:
+  - `StreamApiKey` - API key for Stream backend
+  - `StreamWsUrl` - WebSocket URL (wss://...)
+  - `StreamTokenProvider` implementation - Token fetching logic
+  - Android `Context` - For system service access
+
+**Secrets location:**
+- Token provider responsibility: Secure token minting on consumer's backend
+- API key: Passed to StreamClient at initialization
+- No .env or secrets.json integration in library
+
+## HTTP Interceptor Chain
+
+**Request Order (Outgoing):**
+
+1. **StreamApiKeyInterceptor** - Adds `?api_key=<key>` query parameter
+   - Location: `stream-android-core/src/main/java/io/getstream/android/core/internal/http/interceptor/StreamApiKeyInterceptor.kt`
+
+2. **StreamAuthInterceptor** - Adds JWT authorization header
+   - Location: `stream-android-core/src/main/java/io/getstream/android/core/internal/http/interceptor/StreamAuthInterceptor.kt`
+   - Behavior: Synchronous token loading, automatic single retry with fresh token on codes 40/41/42
+   - Uses `runBlocking` for token operations (OkHttp constraint)
+
+3. **StreamClientInfoInterceptor** - Adds `X-Stream-Client: <version>/<platform>` header
+   - Location: `stream-android-core/src/main/java/io/getstream/android/core/internal/http/interceptor/StreamClientInfoInterceptor.kt`
+
+4. **StreamConnectionIdInterceptor** - Adds `?connection_id=<id>` query parameter if available
+   - Location: `stream-android-core/src/main/java/io/getstream/android/core/internal/http/interceptor/StreamConnectionIdInterceptor.kt`
+
+5. **StreamEndpointErrorInterceptor** - Parses error responses into exceptions
+   - Location: `stream-android-core/src/main/java/io/getstream/android/core/internal/http/interceptor/StreamEndpointErrorInterceptor.kt`
+   - Throws `StreamEndpointException` with parsed error data
+
+**Configuration:**
+- Location: `stream-android-core/src/main/java/io/getstream/android/core/api/model/config/StreamHttpConfig.kt`
+- Enable/disable automatic interceptors: `automaticInterceptors: Boolean = true`
+- Custom interceptors: `configuredInterceptors: Set<Interceptor>`
+- HTTP client builder: `OkHttpClient.Builder` for customization
+
+## Webhooks & Callbacks
+
+**Incoming:**
+- WebSocket events: All incoming events parsed via `StreamCompositeEventSerializationImpl`
+- Core events: `StreamClientConnectedEvent` (connection.ok), `StreamClientConnectionErrorEvent` (connection.error), `StreamHealthCheckEvent` (heartbeat)
+- Product events: Custom event types handled by consumer-provided serializers
+
+**Event Distribution:**
+- Location: `stream-android-core/src/main/java/io/getstream/android/core/api/subscribe/`
+- Interface: `StreamClientListener` - Implement to receive socket events
+- Methods:
+  - `onState(state: StreamConnectionState)` - Connection state changes
+  - `onEvent(event: Any)` - Incoming socket events
+  - `onError(err: Throwable)` - Error notifications
+  - `onRecovery(recovery: Recovery)` - Recovery decision notifications
+- Subscription model: `StreamSubscriptionManager<StreamClientListener>` with retention options (auto-remove or keep-until-cancelled)
+
+**Outgoing (Rewatch on Reconnect):**
+- Interface: `StreamRewatchListener<T>` in `stream-android-core/src/main/java/io/getstream/android/core/api/watcher/StreamRewatchListener.kt`
+- Callback: `suspend fun onRewatch(items: List<T>, connectionId: String)`
+- Triggered: On every `StreamConnectionState.Connected` transition
+- Used by: `StreamWatcher<T>` to re-establish server-side watches after reconnection
+- Managed by: Product SDKs (Chat, Video, Feeds) to re-watch channels/conversations
+
+**Android System Callbacks:**
+- `ConnectivityManager.NetworkCallback` - Network state changes
+- `ProcessLifecycleOwner.Lifecycle` observer - App background/foreground transitions
+- Both monitored by `StreamNetworkMonitor` and `StreamLifecycleMonitor`
+
+## Event Serialization
+
+**JSON Framework:** Moshi 1.15.2
+
+**Code Generation:**
+- KSP generates Moshi adapters at compile time
+- Pattern: `@JsonClass(generateAdapter = true)` on data classes
+- Models location: `stream-android-core/src/main/java/io/getstream/android/core/api/model/`
+- Internal models location: `stream-android-core/src/main/java/io/getstream/android/core/internal/model/`
+
+**Event Types:**
+
+Core Events (Handled by library):
+- `StreamClientConnectedEvent` - type: "connection.ok" - Successful authentication
+- `StreamClientConnectionErrorEvent` - type: "connection.error" - Auth failure
+- `StreamHealthCheckEvent` - type: "health.check" - Periodic heartbeat echo
+
+Product Events:
+- Delegated to consumer-provided serializers
+- Registered via `StreamClientSerializationConfig.productEventSerializers`
+
+**Composite Serialization:**
+- Location: `stream-android-core/src/main/java/io/getstream/android/core/internal/serialization/StreamCompositeEventSerializationImpl.kt`
+- Purpose: Route events to appropriate deserializers based on "type" field
+- Implementation: Peeks JSON "type" field, routes to core or product parser
+
+## Error Handling & Codes
+
+**Error Types:**
+
+- `StreamEndpointException` - API errors from backend
+  - Contains: `code: Int, message: String?, apiError: StreamEndpointErrorData`
+  - Token error codes: 40 (invalid signature), 41 (expired), 42 (revoked)
+  - Location: `stream-android-core/src/main/java/io/getstream/android/core/api/model/exceptions/StreamEndpointException.kt`
+
+- `StreamClientException` - Client-level errors
+  - Socket health failure: "Socket did not receive any events."
+  - Message drop: "Failed to offer message to debounce processor"
+
+- `IOException` - Socket closure
+  - Contains: `"Socket closed. Code: $code, Reason: $reason"`
+
+**Error Extension:**
+- `Result<T>.onTokenError()` - Detects and handles token errors in `Result` type
+- Location: `stream-android-core/src/main/java/io/getstream/android/core/internal/client/StreamClientImpl.kt`
+
+---
+
+*Integration audit: 2026-01-26*

--- a/.planning/codebase/STACK.md
+++ b/.planning/codebase/STACK.md
@@ -1,0 +1,159 @@
+# Technology Stack
+
+**Analysis Date:** 2026-01-26
+
+## Languages
+
+**Primary:**
+- Kotlin 2.2.0 - Primary development language for entire library
+- Java 11 (JVM Target) - Compilation target
+
+**Secondary:**
+- XML - Android configuration files (lint.xml, AndroidManifest.xml)
+- ProGuard - Obfuscation rules (proguard-rules.pro)
+
+## Runtime
+
+**Environment:**
+- Android minSdk 21 (Android 5.0)
+- Android compileSdk 36 (Android 15)
+- Android targetSdk 36 (Android 15)
+
+**Package Manager:**
+- Gradle 8.11.1 (AGP - Android Gradle Plugin)
+- Lockfile: gradle-wrapper.properties (gradle wrapper configured)
+
+## Frameworks
+
+**Core:**
+- Kotlin Coroutines 1.10.2 - Async/await, StateFlow, structured concurrency
+
+**Android:**
+- AndroidX Core 1.7.0 - Core Android support library
+- AndroidX Lifecycle 2.9.4 - Lifecycle observers and management
+- AndroidX Lifecycle Process 2.9.4 - ProcessLifecycleOwner for app background/foreground detection
+
+**Networking:**
+- OkHttp 5.1.0 - HTTP client with WebSocket and interceptor support
+- OkHttp Logging 5.1.0 - Request/response logging interceptor
+- Retrofit 3.0.0 - REST API client (primarily for SDK consumer usage)
+- Moshi 1.15.2 - JSON serialization/deserialization
+
+**Build/Dev:**
+- Detekt 1.23.8 - Kotlin static analysis (code quality)
+- KSP 2.2.0-2.0.2 - Kotlin Symbol Processing for code generation (Moshi adapters)
+- Lint API 31.12.0 - Android lint for custom lint rules
+
+**Testing:**
+- JUnit 4.13.2 - Unit test framework
+- Kotlin Test Library - Kotlin test extensions
+- Robolectric 4.15.1 - Android component testing on JVM
+- MockK 1.14.5 - Kotlin mocking framework
+- OkHttp MockWebServer 5.1.0 - WebSocket and HTTP mocking
+- Kotlinx Coroutines Test 1.10.2 - Coroutine testing utilities
+
+## Key Dependencies
+
+**Critical (Core Functionality):**
+- okhttp (5.1.0) - WebSocket communication with Stream backend
+- moshi (1.15.2) - JSON serialization for API requests/responses
+- kotlinx-coroutines (1.10.2) - Async operations and state management
+- androidx-lifecycle (2.9.4) - Lifecycle-aware connection state and monitoring
+
+**Infrastructure:**
+- retrofit (3.0.0) - Optional REST API support for SDK consumers
+- androidx-annotation-jvm (1.9.1) - Annotations for Lint checks
+- stream-conventions (0.5.0) - Custom build configuration plugin
+
+**Testing Only:**
+- robolectric (4.15.1) - Simulates Android framework in unit tests
+- mockk (1.14.5) - Mocking Kotlin objects
+- mockwebserver (5.1.0) - Mock WebSocket/HTTP responses
+
+## Configuration
+
+**Environment:**
+- Properties-based: `gradle.properties` contains project version (2.0.0) and build settings
+- Local overrides: `local.properties` for machine-specific settings
+- No .env files or external configuration loading
+
+**Key gradle.properties Settings:**
+```
+org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+android.useAndroidX=true
+kotlin.code.style=official
+android.nonTransitiveRClass=true
+version=2.0.0
+```
+
+**Build Configuration:**
+- Multi-module Gradle project (settings.gradle.kts defines modules)
+- Kotlin explicit API mode enabled - all public APIs must have visibility modifiers
+- KSP configured for Moshi code generation (line 72 in stream-android-core/build.gradle.kts)
+- Detekt auto-correct enabled for code quality fixes
+
+**Publishing:**
+- Maven Central publishing (stream-conventions plugin handles versioning)
+- Consumer ProGuard rules: `consumer-rules.pro` distributed with library
+
+## Platform Requirements
+
+**Development:**
+- Android Studio 2024.x or later (API 36 support)
+- Gradle 8.11.1 (via gradle wrapper)
+- JDK 11+ (explicit JVM target 11)
+- Kotlin 2.2.0 compiler
+- KSP compatible IDE/tools
+
+**Production (Consumer Apps):**
+- Android API 21+ (Android 5.0 Lollipop)
+- OkHttp 5.x available (for WebSocket HTTP upgrade)
+- Coroutines support (standard for modern Android)
+- ProcessLifecycleOwner availability (AndroidX Lifecycle)
+
+**Network Requirements:**
+- WebSocket-capable HTTP server
+- Stream backend URL (wss://...)
+- JWT token endpoint for authentication
+
+## Versioning & Release
+
+**Library Version:** 2.0.0 (defined in gradle.properties)
+
+**Kotlin Compatibility:**
+- Kotlin 2.2.0 (latest at analysis date)
+- Targets JVM 11 bytecode
+
+**AndroidX Compatibility:**
+- Uses non-transitive R classes (android.nonTransitiveRClass=true)
+- Explicit AndroidX usage (android.useAndroidX=true)
+
+## Code Generation & Processing
+
+**KSP (Kotlin Symbol Processing):**
+- Location: `stream-android-core/build.gradle.kts:72`
+- Plugin: `ksp` version 2.2.0-2.0.2
+- Used for: Moshi JSON adapter code generation
+- Models: Located in `stream-android-core/src/main/java/io/getstream/android/core/api/model/`
+- Annotations: `@JsonClass(generateAdapter = true)` on data classes
+
+**Detekt (Static Analysis):**
+- Config: `config/detekt/detekt.yml` (root directory)
+- Auto-correct enabled for formatting issues
+- Formatting plugin: `detekt-formatting` 1.23.8
+- Used for: Code quality checks (lines 35-40 in build.gradle.kts)
+
+## Custom Lint Rules
+
+**Location:** `stream-android-core-lint/` module
+
+**Rules Enforced:**
+- StreamApiExplicitMarker - Ensures all public APIs have visibility annotations
+- SuspendRunCatching - Prevents improper exception handling in suspend functions
+- ExposeAsStateFlow - Prevents exposing mutable state flows
+- NoPublicInInternalPackages - Enforces encapsulation of internal packages
+- NotKeepingInstance - Ensures StreamClient instances are retained
+
+---
+
+*Stack analysis: 2026-01-26*

--- a/.planning/codebase/STRUCTURE.md
+++ b/.planning/codebase/STRUCTURE.md
@@ -1,0 +1,297 @@
+# Codebase Structure
+
+**Analysis Date:** 2026-01-26
+
+## Directory Layout
+
+```
+stream-android-core/
+├── src/
+│   ├── main/
+│   │   ├── java/io/getstream/android/core/
+│   │   │   ├── api/                      # Public API contracts (interfaces, data classes)
+│   │   │   │   ├── StreamClient.kt       # Main entry point interface + factory function
+│   │   │   │   ├── authentication/       # Token manager, token provider interfaces
+│   │   │   │   ├── components/           # Android components provider
+│   │   │   │   ├── filter/               # Filter builder interfaces (if applicable)
+│   │   │   │   ├── http/                 # OkHttp interceptor builders
+│   │   │   │   ├── log/                  # Logger provider, logger interface
+│   │   │   │   ├── model/                # Data classes (connection, errors, config, events)
+│   │   │   │   ├── observers/            # Monitor interfaces (network, lifecycle)
+│   │   │   │   ├── processing/           # Processor interfaces (batcher, queue, retry, single-flight)
+│   │   │   │   ├── recovery/             # Connection recovery evaluator interface
+│   │   │   │   ├── serialization/        # Serialization interfaces
+│   │   │   │   ├── socket/               # Socket, WebSocket, health monitor interfaces
+│   │   │   │   ├── sort/                 # Sort builder interfaces (if applicable)
+│   │   │   │   ├── subscribe/            # Subscription manager, listener interfaces
+│   │   │   │   ├── utils/                # Extension functions, utility functions
+│   │   │   │   └── watcher/              # Watcher interface, listener interface
+│   │   │   └── internal/                 # Internal implementations (NOT exposed)
+│   │   │       ├── client/               # StreamClientImpl - main client implementation
+│   │   │       ├── authentication/       # StreamTokenManagerImpl
+│   │   │       ├── components/           # Android component instantiation
+│   │   │       ├── filter/               # Filter implementation (if applicable)
+│   │   │       ├── http/                 # HTTP interceptor implementations
+│   │   │       ├── model/                # Internal-only data classes
+│   │   │       │   ├── authentication/   # Auth request/response models
+│   │   │       │   ├── events/           # Core event types (connection.ok, health.check)
+│   │   │       │   └── network/          # Network request models
+│   │   │       ├── observers/            # Monitor implementations
+│   │   │       │   ├── lifecycle/        # StreamLifecycleMonitorImpl
+│   │   │       │   └── network/          # StreamNetworkMonitorImpl
+│   │   │       ├── processing/           # Processor implementations
+│   │   │       │   ├── StreamBatcherImpl.kt
+│   │   │       │   ├── StreamSerialProcessingQueueImpl.kt
+│   │   │       │   ├── StreamSingleFlightProcessorImpl.kt
+│   │   │       │   ├── StreamRetryProcessorImpl.kt
+│   │   │       │   └── StreamRestartableChannel.kt
+│   │   │       ├── recovery/             # StreamConnectionRecoveryEvaluatorImpl
+│   │   │       ├── serialization/        # Serialization implementations
+│   │   │       │   ├── StreamCompositeEventSerializationImpl.kt
+│   │   │       │   ├── StreamCompositeMoshiJsonSerialization.kt
+│   │   │       │   ├── StreamMoshiJsonSerializationImpl.kt
+│   │   │       │   └── moshi/            # Moshi provider and custom adapters
+│   │   │       ├── socket/               # Socket and WebSocket implementations
+│   │   │       │   ├── StreamSocketSession.kt
+│   │   │       │   ├── StreamWebSocketImpl.kt
+│   │   │       │   ├── SocketConstants.kt
+│   │   │       │   ├── connection/       # Connection models (internal)
+│   │   │       │   ├── factory/          # WebSocket factory implementation
+│   │   │       │   ├── model/            # Socket-specific models (ConnectUserData)
+│   │   │       │   └── monitor/          # StreamHealthMonitorImpl
+│   │   │       ├── sort/                 # Sort implementation (if applicable)
+│   │   │       ├── subscribe/            # Subscription manager implementation
+│   │   │       ├── watcher/              # StreamWatcherImpl - watch registry
+│   │   │       └── (files)               # Direct imports
+│   │   └── res/                          # Android resources (manifests, etc)
+│   ├── test/                             # Unit tests
+│   │   └── java/io/getstream/android/core/
+│   │       └── internal/                 # Test implementations mirror internal/
+│   │           ├── watcher/              # StreamWatcherImplTest.kt
+│   │           ├── processing/           # Processor tests
+│   │           ├── recovery/             # Recovery evaluator tests
+│   │           ├── serialization/        # Serialization tests
+│   │           ├── subscribe/            # Subscription manager tests
+│   │           ├── http/                 # Interceptor tests
+│   │           ├── socket/               # Socket session, health monitor tests
+│   │           ├── authentication/       # Token manager tests
+│   │           ├── client/               # Client implementation tests
+│   │           └── observers/            # Monitor tests
+│   └── androidTest/                      # Instrumented tests (Android-specific)
+│       └── java/io/getstream/android/core/
+├── build.gradle.kts                      # Gradle build configuration
+├── proguard-rules.pro                    # ProGuard obfuscation rules
+└── consumer-rules.pro                    # Consumer-facing ProGuard rules
+
+stream-android-core-annotations/          # Annotations module
+├── src/main/java/io/getstream/android/core/annotations/
+│   ├── StreamPublishedApi.kt              # Stable public API marker
+│   ├── StreamInternalApi.kt               # Internal API marker
+│   └── StreamDelicateApi.kt               # Advanced/dangerous API marker
+
+stream-android-core-lint/                 # Custom Lint checks
+├── src/main/java/io/getstream/android/core/lint/detectors/
+└── src/test/java/io/getstream/android/core/lint/detectors/
+
+app/                                       # Demo application (if applicable)
+├── src/main/java/
+├── src/test/java/
+└── src/androidTest/java/
+```
+
+## Directory Purposes
+
+**api/ (Public contracts):**
+- Purpose: All interfaces, enums, data classes exposed to product SDKs
+- Contains: Stable contracts that should not break between minor versions
+- Key files: `StreamClient.kt`, `StreamConnectionState.kt`, `StreamWatcher.kt`
+
+**api/model/ (Data classes):**
+- Purpose: Data transfer objects and value objects for serialization
+- Contains: Connection state, user data, error data, configuration
+- Key files: `ConnectionState.kt`, `ConnectedUser.kt`, `StreamEndpointErrorData.kt`, `StreamRetryPolicy.kt`
+
+**api/processing/ (Processor interfaces):**
+- Purpose: Interfaces for async work coordination
+- Contains: Batcher, retry processor, single-flight, serial queue
+- Key files: `StreamBatcher.kt`, `StreamSerialProcessingQueue.kt`, `StreamSingleFlightProcessor.kt`
+
+**api/socket/ (Socket interfaces):**
+- Purpose: WebSocket abstraction layer
+- Contains: WebSocket interface, factory, health monitor interface
+- Key files: `StreamWebSocket.kt`, `StreamWebSocketFactory.kt`, `StreamHealthMonitor.kt`
+
+**api/subscribe/ (Subscription interfaces):**
+- Purpose: Listener registration and event dispatch
+- Contains: Subscription manager, observable, subscription interface
+- Key files: `StreamSubscriptionManager.kt`, `StreamObservable.kt`
+
+**api/serialization/ (Serialization contracts):**
+- Purpose: Event and JSON serialization abstractions
+- Contains: Event deserializer, JSON serialization interfaces
+- Key files: `StreamEventSerialization.kt`, `StreamJsonSerialization.kt`
+
+**api/watcher/ (Watch registry):**
+- Purpose: Generic watch management for connection-aware resource tracking
+- Contains: Watcher interface, rewatch listener callback
+- Key files: `StreamWatcher.kt`, `StreamRewatchListener.kt`
+
+**internal/client/ (Client implementation):**
+- Purpose: Main client implementation coordinating all components
+- Contains: `StreamClientImpl` - orchestrates socket, monitors, processors
+- Key files: `StreamClientImpl.kt`
+
+**internal/socket/ (WebSocket layer):**
+- Purpose: WebSocket lifecycle, event batching, authentication
+- Contains: Session manager, socket wrapper, health checks, event routing
+- Key files: `StreamSocketSession.kt`, `StreamWebSocketImpl.kt`, `StreamHealthMonitorImpl.kt`
+
+**internal/processing/ (Concurrency utilities):**
+- Purpose: Backpressure, deduplication, batching, sequential execution
+- Contains: All processor implementations
+- Key files: `StreamBatcherImpl.kt`, `StreamSingleFlightProcessorImpl.kt`, `StreamSerialProcessingQueueImpl.kt`
+
+**internal/serialization/ (Event/JSON handling):**
+- Purpose: Deserialize WebSocket events, route to handlers
+- Contains: Composite serialization, Moshi integration
+- Key files: `StreamCompositeEventSerializationImpl.kt`, `StreamMoshiJsonSerializationImpl.kt`
+
+**internal/authentication/ (Token management):**
+- Purpose: JWT lifecycle, refresh logic, caching
+- Contains: Token manager implementation
+- Key files: `StreamTokenManagerImpl.kt`
+
+**internal/observers/ (Monitoring):**
+- Purpose: Track network connectivity and app lifecycle
+- Contains: Network monitor, lifecycle monitor, aggregated monitor
+- Key files: `StreamNetworkMonitorImpl.kt`, `StreamLifecycleMonitorImpl.kt`
+
+**internal/watcher/ (Watch registry implementation):**
+- Purpose: Maintain watched resources, trigger re-watches on reconnection
+- Contains: Generic watcher implementation
+- Key files: `StreamWatcherImpl.kt`
+
+## Key File Locations
+
+**Entry Points:**
+- `stream-android-core/src/main/java/io/getstream/android/core/api/StreamClient.kt`: Factory function, main interface
+- `stream-android-core/src/main/java/io/getstream/android/core/api/watcher/StreamWatcher.kt`: Watch management factory function
+
+**Configuration:**
+- `build.gradle.kts`: Gradle build, dependencies, KSP setup
+- `stream-android-core/src/main/AndroidManifest.xml`: Android manifest (permissions)
+- `lint.xml`: Android lint configuration
+
+**Core Logic:**
+- `stream-android-core/src/main/java/io/getstream/android/core/internal/client/StreamClientImpl.kt`: Client orchestration
+- `stream-android-core/src/main/java/io/getstream/android/core/internal/socket/StreamSocketSession.kt`: Socket lifecycle
+- `stream-android-core/src/main/java/io/getstream/android/core/internal/socket/StreamWebSocketImpl.kt`: WebSocket wrapper
+
+**Authentication:**
+- `stream-android-core/src/main/java/io/getstream/android/core/internal/authentication/StreamTokenManagerImpl.kt`: Token lifecycle
+- `stream-android-core/src/main/java/io/getstream/android/core/internal/http/interceptor/StreamAuthInterceptor.kt`: JWT injection
+
+**Processing:**
+- `stream-android-core/src/main/java/io/getstream/android/core/internal/processing/StreamBatcherImpl.kt`: Message batching
+- `stream-android-core/src/main/java/io/getstream/android/core/internal/processing/StreamSerialProcessingQueueImpl.kt`: Sequential execution
+- `stream-android-core/src/main/java/io/getstream/android/core/internal/processing/StreamSingleFlightProcessorImpl.kt`: Deduplication
+
+**Testing:**
+- `stream-android-core/src/test/java/io/getstream/android/core/`: Unit test root (mirrors internal structure)
+- `stream-android-core/src/test/java/io/getstream/android/core/internal/watcher/StreamWatcherImplTest.kt`: Watcher tests
+
+## Naming Conventions
+
+**Files:**
+- Impl classes: `StreamXyzImpl.kt` (e.g., `StreamTokenManagerImpl.kt`)
+- Test classes: `<ClassUnderTest>Test.kt` (e.g., `StreamRetryProcessorImplTest.kt`)
+- Interface/factory files: `StreamXyz.kt` (e.g., `StreamClient.kt`, `StreamWatcher.kt`)
+- Internal models: `Stream<DomainObject>Request.kt`, `Stream<DomainObject>Response.kt` (e.g., `StreamWSAuthMessageRequest.kt`)
+
+**Directories:**
+- Internal package: `internal/` - implementation details not exposed
+- API package: `api/` - public stable contracts
+- Component categories: lowercase plural (e.g., `socket/`, `processing/`, `observers/`)
+- Feature grouping: `<feature>/` (e.g., `authentication/`, `serialization/`, `http/`)
+
+**Classes:**
+- Public interfaces: `Stream<Name>` (e.g., `StreamClient`, `StreamBatcher`)
+- Implementations: `Stream<Name>Impl` (e.g., `StreamBatcherImpl`)
+- Event classes: `Stream<Event>Event` (e.g., `StreamClientConnectedEvent`, `StreamHealthCheckEvent`)
+- Request/Response: `Stream<Model><Type>Request/Response` (e.g., `StreamWSAuthMessageRequest`)
+
+**Functions/Methods:**
+- camelCase: `connect()`, `disconnect()`, `reconnect()`
+- Factory functions: Top-level functions matching interface name (e.g., `StreamClient()` factory)
+- Verb-based: `start()`, `stop()`, `watch()`, `subscribe()`, `offer()`
+
+**Variables:**
+- camelCase: `connectionState`, `tokenManager`, `healthMonitor`
+- Private fields: Prefix with underscore for clarity (e.g., `_buffer`, `_state`)
+- Constants: `UPPER_SNAKE_CASE` in `companion object` or top-level
+
+## Where to Add New Code
+
+**New Feature (e.g., new event type):**
+- Event class definition: `stream-android-core/src/main/java/io/getstream/android/core/internal/model/events/Stream<Feature>Event.kt`
+- Public API if needed: `stream-android-core/src/main/java/io/getstream/android/core/api/model/...`
+- Event handling: Update `StreamCompositeEventSerializationImpl.kt` routing if needed
+- Tests: `stream-android-core/src/test/java/io/getstream/android/core/internal/model/events/Stream<Feature>EventTest.kt`
+
+**New Component/Module (e.g., new monitor):**
+- Interface: `stream-android-core/src/main/java/io/getstream/android/core/api/<category>/Stream<Name>.kt`
+- Implementation: `stream-android-core/src/main/java/io/getstream/android/core/internal/<category>/Stream<Name>Impl.kt`
+- Register in: `StreamClient` factory function if it's a dependency
+- Tests: `stream-android-core/src/test/java/io/getstream/android/core/internal/<category>/Stream<Name>ImplTest.kt`
+
+**Utilities/Extensions:**
+- Shared helpers: `stream-android-core/src/main/java/io/getstream/android/core/api/utils/`
+- Internal helpers: `stream-android-core/src/main/java/io/getstream/android/core/internal/` (in same package as usage)
+- Extension functions: Top-level in same file or in `utils/` package
+- Tests: Co-located with implementation file using `Test` suffix
+
+**Data Models:**
+- Public models: `stream-android-core/src/main/java/io/getstream/android/core/api/model/<domain>/`
+- Internal models: `stream-android-core/src/main/java/io/getstream/android/core/internal/model/<domain>/`
+- Use `@JsonClass(generateAdapter = true)` for Moshi serialization
+
+**HTTP Interceptors:**
+- Location: `stream-android-core/src/main/java/io/getstream/android/core/internal/http/interceptor/Stream<Name>Interceptor.kt`
+- Add to chain: Update `StreamClient.kt` factory function (lines 317-330) to add interceptor to builder
+- Tests: `stream-android-core/src/test/java/io/getstream/android/core/internal/http/interceptor/Stream<Name>InterceptorTest.kt`
+
+## Special Directories
+
+**annotations/ (Visibility annotations):**
+- Purpose: Mark APIs with stability guarantees
+- Generated: No - hand-written annotations
+- Committed: Yes - part of source tree
+- Files: `StreamPublishedApi.kt`, `StreamInternalApi.kt`, `StreamDelicateApi.kt`
+
+**build/ (Build outputs):**
+- Purpose: Compiled classes, resources, AAR, test reports
+- Generated: Yes - from gradle build
+- Committed: No - .gitignored
+- Location: `stream-android-core/build/`
+
+**.gradle/ (Gradle cache):**
+- Purpose: Gradle build cache and metadata
+- Generated: Yes - by gradle daemon
+- Committed: No - .gitignored
+- Location: Project root and module-level
+
+**config/ (Build configuration):**
+- Purpose: Detekt rules, lint configuration
+- Generated: No - hand-written
+- Committed: Yes
+- Location: `config/detekt/detekt.yml`
+
+**buildSrc/ (Build logic):**
+- Purpose: Gradle plugins and version management
+- Generated: No - hand-written
+- Committed: Yes
+- Location: `buildSrc/src/main/kotlin/`
+
+---
+
+*Structure analysis: 2026-01-26*

--- a/.planning/codebase/TESTING.md
+++ b/.planning/codebase/TESTING.md
@@ -1,0 +1,384 @@
+# Testing Patterns
+
+**Analysis Date:** 2026-01-26
+
+## Test Framework
+
+**Runner:**
+- JUnit 4 (dependency: `junit` via gradle libs)
+- Kotlin test support (dependency: `kotlin("test")`)
+- Config: Build configuration in `stream-android-core/build.gradle.kts`
+
+**Assertion Library:**
+- `org.junit.Assert.*` for primary assertions
+- `kotlin.test.assert*` functions available as alternatives
+- Assertions: `assertTrue()`, `assertFalse()`, `assertEquals()`, `assertSame()`, `assertNull()`, `assertThrows()`
+
+**Run Commands:**
+```bash
+# Run all unit tests
+./gradlew :stream-android-core:test
+
+# Run specific test class
+./gradlew :stream-android-core:test --tests "io.getstream.android.core.internal.processing.StreamRetryProcessorImplTest"
+
+# Run specific test method
+./gradlew :stream-android-core:test --tests "io.getstream.android.core.internal.processing.StreamRetryProcessorImplTest.testExponentialBackoff"
+
+# Run tests with coverage report
+./gradlew koverHtmlReportCoverage
+# Coverage report: stream-android-core/build/reports/kover/htmlCoverage/index.html
+
+# Run instrumented tests on connected device
+./gradlew :stream-android-core:connectedDebugAndroidTest
+```
+
+## Test File Organization
+
+**Location:**
+- Unit tests: `stream-android-core/src/test/java/io/getstream/android/core/`
+- Instrumented tests: `stream-android-core/src/androidTest/java/io/getstream/android/core/`
+- Mirror source package structure: Test class location mirrors source class location
+
+**Naming:**
+- Pattern: `<ClassUnderTest>Test.kt`
+- Examples:
+  - `stream-android-core/src/test/java/io/getstream/android/core/internal/processing/StreamRetryProcessorImplTest.kt`
+  - `stream-android-core/src/test/java/io/getstream/android/core/internal/watcher/StreamWatcherImplTest.kt`
+  - `stream-android-core/src/test/java/io/getstream/android/core/internal/processing/StreamSingleFlightProcessorImplTest.kt`
+
+**Structure:**
+```
+stream-android-core/src/test/java/io/getstream/android/core/
+├── internal/
+│   ├── processing/
+│   │   ├── StreamRetryProcessorImplTest.kt
+│   │   ├── StreamBatcherImplTest.kt
+│   │   ├── StreamSingleFlightProcessorImplTest.kt
+│   │   └── StreamSerialProcessingQueueImplTest.kt
+│   ├── watcher/
+│   │   └── StreamWatcherImplTest.kt
+│   ├── serialization/
+│   │   ├── StreamMoshiJsonSerializationImplTest.kt
+│   │   └── StreamCompositeEventSerializationImplTest.kt
+│   └── ...
+```
+
+## Test Structure
+
+**Suite Organization:**
+
+Test classes use JUnit 4 structure with `@Before` setup and organized `@Test` methods:
+
+```kotlin
+class StreamRetryProcessorImplTest {
+
+    private val retry = StreamRetryProcessorImpl(mockk(relaxed = true))
+
+    @Test
+    fun `returns success immediately when block succeeds on first attempt`() = runTest {
+        val policy = StreamRetryPolicy.linear(initialDelayMillis = 0)
+        val counter = AtomicInteger()
+
+        val res = retry.retry(policy) {
+            counter.incrementAndGet()
+            "OK"
+        }
+
+        assertTrue(res.isSuccess)
+        assertEquals("OK", res.getOrNull())
+        assertEquals(1, counter.get())
+    }
+}
+```
+
+**Patterns:**
+
+**Setup Pattern:**
+```kotlin
+class StreamWatcherImplTest {
+
+    private lateinit var logger: StreamLogger
+    private lateinit var rewatchSubscriptions: StreamSubscriptionManager<StreamRewatchListener<String>>
+    private lateinit var connectionState: MutableStateFlow<StreamConnectionState>
+    private lateinit var watcher: StreamWatcher<String>
+    private lateinit var scope: CoroutineScope
+
+    @Before
+    fun setUp() {
+        logger = mockk(relaxed = true)
+        rewatchSubscriptions = mockk(relaxed = true)
+        connectionState = MutableStateFlow(StreamConnectionState.Idle)
+        scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+
+        watcher = StreamWatcherImpl(
+            scope = scope,
+            connectionState = connectionState,
+            rewatchSubscriptions = rewatchSubscriptions,
+            logger = logger,
+        )
+    }
+}
+```
+
+**Teardown Pattern:**
+- Implicit via test framework lifecycle
+- Coroutine scopes automatically cleaned up after test
+- No explicit `@After` needed for mocks (MockK handles cleanup)
+
+**Assertion Pattern:**
+```kotlin
+@Test
+fun `watch adds CID to registry`() {
+    val cid = "messaging:general"
+
+    val result = watcher.watch(cid)
+
+    assertTrue(result.isSuccess)
+    assertEquals(cid, result.getOrNull())
+    assertTrue(watched.containsKey(cid))
+}
+```
+
+**Test Naming Convention:**
+- Backtick names describing behavior: `` `function does something when condition` ``
+- Examples:
+  - `` `returns success immediately when block succeeds on first attempt` ``
+  - `` `watch adds CID to registry` ``
+  - `` `retries until block succeeds before reaching maxRetries` ``
+
+## Mocking
+
+**Framework:** MockK
+- Dependency: `mockk` via gradle libs
+- Supports both blocking and suspend functions via `coEvery`, `coVerify`
+
+**Patterns:**
+
+**Basic Mocking:**
+```kotlin
+val logger: StreamLogger = mockk(relaxed = true)  // Relaxed: all calls return default values
+val worker: Worker = mockk()  // Strict: must specify behavior
+
+coEvery { worker.workInt() } coAnswers {
+    delay(1_000)
+    42
+}
+```
+
+**Verification:**
+```kotlin
+coVerify(exactly = 1) { worker.workInt() }  // Verify called exactly once
+coVerify(atLeast = 2) { worker.workInt() }  // Verify called at least twice
+verify(exactly = 0) { worker.workInt() }    // Verify never called
+```
+
+**Custom Test Collaborators:**
+```kotlin
+class RecordingMap<K, V>(private val delegate: ConcurrentMap<K, V> = ConcurrentHashMap()) :
+    ConcurrentMap<K, V> by delegate {
+    val installedNonNull = java.util.concurrent.atomic.AtomicBoolean(false)
+
+    override fun putIfAbsent(key: K, value: V): V? {
+        val existing = delegate.putIfAbsent(key, value)
+        if (existing != null) installedNonNull.set(true)
+        return existing
+    }
+}
+```
+
+**What to Mock:**
+- Logger instances (always relaxed: `mockk(relaxed = true)`)
+- Listener interfaces/callbacks for event verification
+- Collaborators with side effects or long-running operations
+- Dependencies that would require real network/database
+
+**What NOT to Mock:**
+- Value objects and data classes - instantiate directly
+- Sealed classes and enums - use actual instances
+- Result types - use `Result.success()` and `Result.failure()`
+- StateFlow/Flow - use `MutableStateFlow` instead
+- Coroutine-related utilities from kotlinx.coroutines - use real implementations
+
+## Fixtures and Factories
+
+**Test Data:**
+- Test uses inline factory functions within test files
+- No separate fixture library; data created directly in tests
+- Use `mockk` for complex object creation with specific behaviors
+
+**Example Fixture:**
+```kotlin
+@Test
+fun `watch adds CID to registry`() {
+    val cid = "messaging:general"  // Inline test data
+
+    val result = watcher.watch(cid)
+
+    assertTrue(result.isSuccess)
+}
+```
+
+**Location:**
+- Fixtures created locally within test methods or `@Before` setup
+- Shared test data in top-level test class properties
+- No separate test fixtures directory
+
+## Coverage
+
+**Requirements:**
+- No enforced minimum coverage percentage
+- Kover integrated for measurement and HTML reporting
+- Coverage analyzed per module
+
+**View Coverage:**
+```bash
+# Generate coverage report
+./gradlew koverHtmlReportCoverage
+
+# Open HTML report
+open stream-android-core/build/reports/kover/htmlCoverage/index.html
+```
+
+**Kover Configuration:**
+- Tool: Kover (Kotlin coverage engine)
+- Report format: HTML with line/instruction/branch coverage
+- Integration: Gradle plugin configured in build.gradle.kts
+
+## Test Types
+
+**Unit Tests:**
+- Scope: Individual functions and classes in isolation
+- Approach: Mock external dependencies, test logic paths
+- Location: `stream-android-core/src/test/java/`
+- Examples:
+  - `StreamRetryProcessorImplTest.kt` - Tests retry logic with mocked logger
+  - `StreamSingleFlightProcessorImplTest.kt` - Tests deduplication with custom mocks
+  - `StreamWatcherImplTest.kt` - Tests watch registry and state observation
+
+**Integration Tests:**
+- Scope: Multiple components working together (without network)
+- Approach: Real implementations, no mocking except external services
+- Example: Connection state change triggering rewatch callbacks
+- Use: `MutableStateFlow` for state injection, real coroutine scopes
+
+**E2E Tests:**
+- Status: Not implemented (Android Instrumented tests possible via `connectedDebugAndroidTest`)
+- Would require device/emulator setup
+- Not currently in scope for unit test suite
+
+## Common Patterns
+
+**Async Testing:**
+```kotlin
+@OptIn(ExperimentalCoroutinesApi::class)
+@Test
+fun `retries until block succeeds before reaching maxRetries`() = runTest {
+    val dispatcher = StandardTestDispatcher(testScheduler)
+    val scope = TestScope(dispatcher)
+
+    val counter = AtomicInteger(1)
+    val job = scope.async {
+        retry.retry(policy) {
+            when (counter.incrementAndGet()) {
+                1, 2 -> error("Boom")
+                else -> "OK"
+            }
+        }
+    }
+
+    dispatcher.scheduler.advanceUntilIdle()  // Execute scheduled delays
+
+    val res = job.await()
+    assertTrue(res.isSuccess)
+}
+```
+
+**Coroutine Testing with TestDispatchers:**
+- Use `runTest { ... }` from `kotlinx.coroutines.test`
+- Create `StandardTestDispatcher` for virtual time control
+- Advance time: `advanceUntilIdle()` or `advanceTimeBy(ms)`
+- Verify suspension behavior without real delays
+
+**Error Testing:**
+```kotlin
+@Test
+fun `returns failure after exhausting maxRetries`() = runTest {
+    val policy = StreamRetryPolicy.linear(maxRetries = 2, minRetries = 1)
+    val boom = RuntimeException("boom")
+
+    val res = retry.retry(policy) { throw boom }
+
+    assertTrue(res.isFailure)
+    assertSame(boom, res.exceptionOrNull())  // Exact same exception object
+}
+```
+
+**State Flow Observation Testing:**
+```kotlin
+@Test
+fun `triggers rewatch on connection state change`() = runTest {
+    val connectionState = MutableStateFlow<StreamConnectionState>(StreamConnectionState.Idle)
+
+    watcher.start()
+    watcher.watch("channel:1")
+
+    // Emit Connected state
+    connectionState.value = StreamConnectionState.Connected(
+        user = mockk(),
+        connectionId = "conn-123"
+    )
+
+    advanceUntilIdle()  // Let collector process state change
+
+    // Verify listener was invoked with correct data
+    verify { listener.onRewatch(setOf("channel:1"), "conn-123") }
+}
+```
+
+**Robolectric for Android Components:**
+```kotlin
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [Build.VERSION_CODES.UPSIDE_DOWN_CAKE])
+class LifecycleMonitorTest {
+
+    @Test
+    fun testLifecycleMonitor() {
+        // Can use real Android components like ProcessLifecycleOwner
+        val monitor = StreamLifecycleMonitorImpl(logger)
+        // Test with actual Android lifecycle callbacks
+    }
+}
+```
+
+## Test Isolation & Cleanup
+
+**Resource Management:**
+- Coroutine scopes created with `SupervisorJob()` in setup
+- Dispatcher resets between test methods
+- MockK automatically clears mocks after each test
+- MutableStateFlow instances created fresh per test
+
+**Concurrency Testing:**
+```kotlin
+@Test
+fun `concurrent start and stop calls are thread-safe`() = runTest {
+    val dispatcher = StandardTestDispatcher(testScheduler)
+    val scope = CoroutineScope(SupervisorJob() + dispatcher)
+
+    val jobs = (1..10).map {
+        scope.async { watcher.start() }
+    } + (1..10).map {
+        scope.async { watcher.stop() }
+    }
+
+    dispatcher.scheduler.advanceUntilIdle()
+
+    jobs.forEach { job -> job.await() }
+    // Verify final state is consistent
+}
+```
+
+---
+
+*Testing analysis: 2026-01-26*

--- a/.planning/config.json
+++ b/.planning/config.json
@@ -1,0 +1,12 @@
+{
+  "mode": "yolo",
+  "depth": "standard",
+  "parallelization": true,
+  "commit_docs": true,
+  "model_profile": "quality",
+  "workflow": {
+    "research": true,
+    "plan_check": true,
+    "verifier": true
+  }
+}

--- a/stream-android-core/src/main/java/io/getstream/android/core/api/utils/List.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/api/utils/List.kt
@@ -1,2 +1,0 @@
-package io.getstream.android.core.api.utils
-

--- a/stream-android-core/src/main/java/io/getstream/android/core/api/utils/List.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/api/utils/List.kt
@@ -1,0 +1,2 @@
+package io.getstream.android.core.api.utils
+


### PR DESCRIPTION
### Goal

Set up GSD (Get Shit Done) planning infrastructure for this project, including codebase analysis and project initialization.

### Implementation

**Codebase mapping** (`.planning/codebase/`):
- STACK.md - Technologies and dependencies
- ARCHITECTURE.md - System design and patterns
- STRUCTURE.md - Directory layout and organization
- CONVENTIONS.md - Code style and patterns
- TESTING.md - Test structure and practices
- INTEGRATIONS.md - External services and APIs
- CONCERNS.md - Technical debt and issues

**Project initialization** (`.planning/`):
- PROJECT.md - Project context with validated requirements from existing code
- config.json - Workflow preferences (yolo mode, standard depth, parallel execution, quality models)
- STATE.md - Project state tracking

### Testing

- [x] All 7 codebase documents created
- [x] PROJECT.md captures existing capabilities as validated requirements
- [x] config.json has valid workflow settings
- [x] STATE.md initialized