### PR TITLE
Update conventions to version 0.9.0

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   android-ci:
-    uses: GetStream/stream-build-conventions-android/.github/workflows/android-ci.yml@v0.6.0
+    uses: GetStream/stream-build-conventions-android/.github/workflows/android-ci.yml@v0.9.0
     secrets: inherit
     with:
       api-check: false

--- a/.github/workflows/pr-clean-stale.yaml
+++ b/.github/workflows/pr-clean-stale.yaml
@@ -12,5 +12,5 @@ permissions:
 
 jobs:
   pr-clean-stale:
-    uses: GetStream/stream-build-conventions-android/.github/workflows/pr-clean-stale.yaml@v0.6.0
+    uses: GetStream/stream-build-conventions-android/.github/workflows/pr-clean-stale.yaml@v0.9.0
     secrets: inherit

--- a/.github/workflows/pr-quality.yml
+++ b/.github/workflows/pr-quality.yml
@@ -15,5 +15,5 @@ concurrency:
 
 jobs:
   pr-checklist:
-    uses: GetStream/stream-build-conventions-android/.github/workflows/pr-quality.yml@v0.6.0
+    uses: GetStream/stream-build-conventions-android/.github/workflows/pr-quality.yml@v0.9.0
     secrets: inherit

--- a/.github/workflows/publish-new-version.yml
+++ b/.github/workflows/publish-new-version.yml
@@ -30,7 +30,7 @@ jobs:
     permissions:
       contents: write
     needs: pre_release_check
-    uses: GetStream/stream-build-conventions-android/.github/workflows/release.yml@v0.5.0
+    uses: GetStream/stream-build-conventions-android/.github/workflows/release.yml@v0.9.0
     with:
       bump: ${{ inputs.bump }}
     secrets:


### PR DESCRIPTION
### Goal

Update all workflow references to stream-build-conventions-android to v0.9.0 for consistency and latest CI improvements.

### Implementation

Updated version tags in workflow files from mixed versions (v0.5.0, v0.6.0) to v0.9.0:
- publish-new-version.yml
- pr-clean-stale.yaml
- pr-quality.yml
- android.yml

### Testing

CI workflows will run on this PR to validate changes.

### Checklist
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform)