### PR TITLE
Redact token values from debug logs

### DIFF
--- a/stream-android-core/src/main/java/io/getstream/android/core/api/model/value/StreamToken.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/api/model/value/StreamToken.kt
@@ -26,6 +26,8 @@ import io.getstream.android.core.annotations.StreamPublishedApi
 @StreamPublishedApi
 @JvmInline
 public value class StreamToken private constructor(public val rawValue: String) {
+    override fun toString(): String = "StreamToken(<redacted>)"
+
     public companion object {
         /**
          * Creates a new [StreamToken] from a string.

--- a/stream-android-core/src/main/java/io/getstream/android/core/internal/socket/StreamSocketSession.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/internal/socket/StreamSocketSession.kt
@@ -345,7 +345,9 @@ internal class StreamSocketSession<T>(
                             eventParser
                                 .serialize(StreamCompositeSerializationEvent.internal(authRequest))
                                 .mapCatching {
-                                    logger.v { "[onOpen] Sending auth request: $it" }
+                                    logger.v {
+                                        "[onOpen] Sending auth request (${it.length} bytes)"
+                                    }
                                     internalSocket.send(it)
                                 }
                                 .onFailure {

--- a/stream-android-core/src/main/java/io/getstream/android/core/internal/socket/model/ConnectUserData.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/internal/socket/model/ConnectUserData.kt
@@ -35,4 +35,7 @@ internal data class ConnectUserData(
     val invisible: Boolean = false,
     val language: String? = null,
     val custom: Map<String, Any?>? = null,
-)
+) {
+    override fun toString(): String =
+        "ConnectUserData(userId=$userId, token=<redacted>, name=$name, invisible=$invisible)"
+}


### PR DESCRIPTION
### Goal

Prevent JWT tokens from leaking into LogCat, crash reports, and monitoring systems.

### Implementation

- `ConnectUserData.toString()` — custom override that prints `<redacted>` instead of the raw token
- `StreamToken.toString()` — returns `StreamToken(<redacted>)` instead of the raw value
- `StreamSocketSession` auth request log — prints byte count instead of the serialized JSON payload containing the token

### Testing

Existing tests pass. Token redaction is structural (toString override) — no runtime behavior change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Improvements**
  * Authentication tokens and sensitive credentials are now redacted in application logs and string representations to prevent accidental data exposure.
  * Verbose logging during authentication now displays payload size instead of full serialized content, further protecting sensitive information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->