### PR TITLE
Update build conventions to v0.10.0

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   android-ci:
-    uses: GetStream/stream-build-conventions-android/.github/workflows/android-ci.yml@v0.9.0
+    uses: GetStream/stream-build-conventions-android/.github/workflows/android-ci.yml@v0.10.0
     secrets: inherit
     with:
       api-check: false

--- a/.github/workflows/pr-clean-stale.yaml
+++ b/.github/workflows/pr-clean-stale.yaml
@@ -12,5 +12,5 @@ permissions:
 
 jobs:
   pr-clean-stale:
-    uses: GetStream/stream-build-conventions-android/.github/workflows/pr-clean-stale.yaml@v0.9.0
+    uses: GetStream/stream-build-conventions-android/.github/workflows/pr-clean-stale.yaml@v0.10.0
     secrets: inherit

--- a/.github/workflows/pr-quality.yml
+++ b/.github/workflows/pr-quality.yml
@@ -15,5 +15,5 @@ concurrency:
 
 jobs:
   pr-checklist:
-    uses: GetStream/stream-build-conventions-android/.github/workflows/pr-quality.yml@v0.9.0
+    uses: GetStream/stream-build-conventions-android/.github/workflows/pr-quality.yml@v0.10.0
     secrets: inherit

--- a/.github/workflows/publish-new-version.yml
+++ b/.github/workflows/publish-new-version.yml
@@ -30,7 +30,7 @@ jobs:
     permissions:
       contents: write
     needs: pre_release_check
-    uses: GetStream/stream-build-conventions-android/.github/workflows/release.yml@v0.9.0
+    uses: GetStream/stream-build-conventions-android/.github/workflows/release.yml@v0.10.0
     with:
       bump: ${{ inputs.bump }}
     secrets:


### PR DESCRIPTION
### Goal

Update `stream-build-conventions-android` workflow references to the latest version (v0.10.0).

### Implementation

Bumped the `@v0.9.0` tag to `@v0.10.0` in all four CI workflow files:

- `android.yml` — android-ci
- `pr-quality.yml` — PR checklist
- `pr-clean-stale.yaml` — stale PR cleanup
- `publish-new-version.yml` — release publishing

### Testing

CI workflows will validate themselves — this PR's checks run on the updated conventions.