### PR TITLE
Bump gradle conventions plugin to v0.10.0

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-    Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+    Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
 
     Licensed under the Stream License;
     you may not use this file except in compliance with the License.

--- a/app/src/main/java/io/getstream/android/core/sample/SampleActivity.kt
+++ b/app/src/main/java/io/getstream/android/core/sample/SampleActivity.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/app/src/main/java/io/getstream/android/core/sample/SampleApp.kt
+++ b/app/src/main/java/io/getstream/android/core/sample/SampleApp.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/app/src/main/java/io/getstream/android/core/sample/ui/ConnectionStateCard.kt
+++ b/app/src/main/java/io/getstream/android/core/sample/ui/ConnectionStateCard.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/app/src/main/java/io/getstream/android/core/sample/ui/NetworkInfoCard.kt
+++ b/app/src/main/java/io/getstream/android/core/sample/ui/NetworkInfoCard.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/app/src/main/java/io/getstream/android/core/sample/ui/NetworkInfoComponents.kt
+++ b/app/src/main/java/io/getstream/android/core/sample/ui/NetworkInfoComponents.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/app/src/main/java/io/getstream/android/core/sample/ui/theme/Color.kt
+++ b/app/src/main/java/io/getstream/android/core/sample/ui/theme/Color.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/app/src/main/java/io/getstream/android/core/sample/ui/theme/Theme.kt
+++ b/app/src/main/java/io/getstream/android/core/sample/ui/theme/Theme.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/app/src/main/java/io/getstream/android/core/sample/ui/theme/Type.kt
+++ b/app/src/main/java/io/getstream/android/core/sample/ui/theme/Type.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/app/src/main/res/drawable-v24/ic_launcher_foreground.xml
+++ b/app/src/main/res/drawable-v24/ic_launcher_foreground.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-    Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+    Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
 
     Licensed under the Stream License;
     you may not use this file except in compliance with the License.

--- a/app/src/main/res/drawable/ic_launcher_background.xml
+++ b/app/src/main/res/drawable/ic_launcher_background.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-    Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+    Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
 
     Licensed under the Stream License;
     you may not use this file except in compliance with the License.

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-    Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+    Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
 
     Licensed under the Stream License;
     you may not use this file except in compliance with the License.

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-    Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+    Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
 
     Licensed under the Stream License;
     you may not use this file except in compliance with the License.

--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-    Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+    Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
 
     Licensed under the Stream License;
     you may not use this file except in compliance with the License.

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-    Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+    Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
 
     Licensed under the Stream License;
     you may not use this file except in compliance with the License.

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-    Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+    Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
 
     Licensed under the Stream License;
     you may not use this file except in compliance with the License.

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-    Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+    Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
 
     Licensed under the Stream License;
     you may not use this file except in compliance with the License.

--- a/app/src/main/res/xml/backup_rules.xml
+++ b/app/src/main/res/xml/backup_rules.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-    Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+    Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
 
     Licensed under the Stream License;
     you may not use this file except in compliance with the License.

--- a/app/src/main/res/xml/data_extraction_rules.xml
+++ b/app/src/main/res/xml/data_extraction_rules.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-    Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+    Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
 
     Licensed under the Stream License;
     you may not use this file except in compliance with the License.

--- a/app/src/test/java/io/getstream/android/core/ExampleUnitTest.kt
+++ b/app/src/test/java/io/getstream/android/core/ExampleUnitTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -26,7 +26,7 @@ retrofit = "3.0.0"
 ksp = "2.2.0-2.0.2"
 robolectric = "4.15.1"
 detekt = "1.23.8"
-streamConventions = "0.5.0"
+streamConventions = "0.10.0"
 annotationJvm = "1.9.1"
 
 [libraries]

--- a/stream-android-core-annotations/src/main/java/io/getstream/android/core/annotations/StreamApiMarkers.kt
+++ b/stream-android-core-annotations/src/main/java/io/getstream/android/core/annotations/StreamApiMarkers.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core-lint/src/main/java/io/getstream/android/core/lint/StreamIssueRegistry.kt
+++ b/stream-android-core-lint/src/main/java/io/getstream/android/core/lint/StreamIssueRegistry.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core-lint/src/main/java/io/getstream/android/core/lint/detectors/ExposeAsStateFlowDetector.kt
+++ b/stream-android-core-lint/src/main/java/io/getstream/android/core/lint/detectors/ExposeAsStateFlowDetector.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core-lint/src/main/java/io/getstream/android/core/lint/detectors/KeepInstanceDetector.kt
+++ b/stream-android-core-lint/src/main/java/io/getstream/android/core/lint/detectors/KeepInstanceDetector.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core-lint/src/main/java/io/getstream/android/core/lint/detectors/MustBeInternalDetector.kt
+++ b/stream-android-core-lint/src/main/java/io/getstream/android/core/lint/detectors/MustBeInternalDetector.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core-lint/src/main/java/io/getstream/android/core/lint/detectors/StreamApiExplicitMarkerDetector.kt
+++ b/stream-android-core-lint/src/main/java/io/getstream/android/core/lint/detectors/StreamApiExplicitMarkerDetector.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core-lint/src/main/java/io/getstream/android/core/lint/detectors/SuspendRunCatchingDetector.kt
+++ b/stream-android-core-lint/src/main/java/io/getstream/android/core/lint/detectors/SuspendRunCatchingDetector.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/AndroidManifest.xml
+++ b/stream-android-core/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-    Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+    Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
 
     Licensed under the Stream License;
     you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/api/StreamClient.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/api/StreamClient.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/api/authentication/StreamTokenManager.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/api/authentication/StreamTokenManager.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/api/authentication/StreamTokenProvider.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/api/authentication/StreamTokenProvider.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/api/components/StreamAndroidComponentsProvider.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/api/components/StreamAndroidComponentsProvider.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/api/filter/Filter.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/api/filter/Filter.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/api/filter/FilterField.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/api/filter/FilterField.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/api/filter/Filters.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/api/filter/Filters.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/api/http/StreamOkHttpInterceptors.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/api/http/StreamOkHttpInterceptors.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/api/log/StreamLogger.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/api/log/StreamLogger.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/api/log/StreamLoggerProvider.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/api/log/StreamLoggerProvider.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/api/model/StreamTypedKey.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/api/model/StreamTypedKey.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/api/model/StreamUser.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/api/model/StreamUser.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/api/model/config/StreamClientSerializationConfig.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/api/model/config/StreamClientSerializationConfig.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/api/model/config/StreamComponentProvider.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/api/model/config/StreamComponentProvider.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/api/model/config/StreamHttpConfig.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/api/model/config/StreamHttpConfig.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/api/model/config/StreamSocketConfig.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/api/model/config/StreamSocketConfig.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/api/model/connection/StreamConnectedUser.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/api/model/connection/StreamConnectedUser.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/api/model/connection/StreamConnectionState.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/api/model/connection/StreamConnectionState.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/api/model/connection/lifecycle/StreamLifecycleState.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/api/model/connection/lifecycle/StreamLifecycleState.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/api/model/connection/network/StreamNetworkInfo.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/api/model/connection/network/StreamNetworkInfo.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/api/model/connection/network/StreamNetworkState.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/api/model/connection/network/StreamNetworkState.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/api/model/connection/recovery/Recovery.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/api/model/connection/recovery/Recovery.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/api/model/event/StreamClientWsEvent.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/api/model/event/StreamClientWsEvent.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/api/model/exceptions/Exceptions.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/api/model/exceptions/Exceptions.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/api/model/exceptions/StreamEndpointErrorData.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/api/model/exceptions/StreamEndpointErrorData.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/api/model/location/BoundingBox.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/api/model/location/BoundingBox.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/api/model/location/CircularRegion.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/api/model/location/CircularRegion.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/api/model/location/Distance.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/api/model/location/Distance.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/api/model/location/LocationCoordinate.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/api/model/location/LocationCoordinate.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/api/model/retry/StreamRetryAttemptInfo.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/api/model/retry/StreamRetryAttemptInfo.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/api/model/retry/StreamRetryPolicy.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/api/model/retry/StreamRetryPolicy.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/api/model/value/StreamApiKey.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/api/model/value/StreamApiKey.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/api/model/value/StreamHttpClientInfoHeader.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/api/model/value/StreamHttpClientInfoHeader.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/api/model/value/StreamHttpUrl.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/api/model/value/StreamHttpUrl.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/api/model/value/StreamToken.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/api/model/value/StreamToken.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/api/model/value/StreamUserId.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/api/model/value/StreamUserId.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/api/model/value/StreamWsUrl.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/api/model/value/StreamWsUrl.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/api/observers/StreamStartableComponent.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/api/observers/StreamStartableComponent.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/api/observers/lifecycle/StreamLifecycleListener.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/api/observers/lifecycle/StreamLifecycleListener.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/api/observers/lifecycle/StreamLifecycleMonitor.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/api/observers/lifecycle/StreamLifecycleMonitor.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/api/observers/network/StreamNetworkMonitor.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/api/observers/network/StreamNetworkMonitor.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/api/observers/network/StreamNetworkMonitorListener.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/api/observers/network/StreamNetworkMonitorListener.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/api/processing/StreamBatcher.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/api/processing/StreamBatcher.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/api/processing/StreamDebouncer.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/api/processing/StreamDebouncer.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/api/processing/StreamRetryProcessor.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/api/processing/StreamRetryProcessor.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/api/processing/StreamSerialProcessingQueue.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/api/processing/StreamSerialProcessingQueue.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/api/processing/StreamSingleFlightProcessor.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/api/processing/StreamSingleFlightProcessor.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/api/processing/StreamThrottlePolicy.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/api/processing/StreamThrottlePolicy.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/api/processing/StreamThrottler.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/api/processing/StreamThrottler.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/api/recovery/StreamConnectionRecoveryEvaluator.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/api/recovery/StreamConnectionRecoveryEvaluator.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/api/serialization/StreamEventSerialization.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/api/serialization/StreamEventSerialization.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/api/serialization/StreamJsonSerialization.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/api/serialization/StreamJsonSerialization.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/api/socket/StreamConnectionIdHolder.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/api/socket/StreamConnectionIdHolder.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/api/socket/StreamWebSocket.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/api/socket/StreamWebSocket.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/api/socket/StreamWebSocketFactory.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/api/socket/StreamWebSocketFactory.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/api/socket/listeners/StreamClientListener.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/api/socket/listeners/StreamClientListener.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/api/socket/listeners/StreamWebSocketListener.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/api/socket/listeners/StreamWebSocketListener.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/api/socket/monitor/StreamHealthMonitor.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/api/socket/monitor/StreamHealthMonitor.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/api/sort/Sort.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/api/sort/Sort.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/api/sort/SortComparator.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/api/sort/SortComparator.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/api/sort/SortDirection.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/api/sort/SortDirection.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/api/sort/SortField.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/api/sort/SortField.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/api/subscribe/StreamObservable.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/api/subscribe/StreamObservable.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/api/subscribe/StreamSubscription.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/api/subscribe/StreamSubscription.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/api/subscribe/StreamSubscriptionManager.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/api/subscribe/StreamSubscriptionManager.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/api/utils/Algebra.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/api/utils/Algebra.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/api/utils/Catching.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/api/utils/Catching.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/api/utils/Flows.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/api/utils/Flows.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/api/utils/Map.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/api/utils/Map.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/api/utils/Response.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/api/utils/Response.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/api/utils/Result.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/api/utils/Result.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/api/utils/Threading.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/api/utils/Threading.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/api/watcher/StreamRewatchListener.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/api/watcher/StreamRewatchListener.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/api/watcher/StreamWatcher.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/api/watcher/StreamWatcher.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/internal/authentication/StreamTokenManagerImpl.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/internal/authentication/StreamTokenManagerImpl.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/internal/client/StreamClientImpl.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/internal/client/StreamClientImpl.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/internal/components/StreamAndroidComponentsProviderImpl.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/internal/components/StreamAndroidComponentsProviderImpl.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/internal/filter/FilterOperations.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/internal/filter/FilterOperations.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/internal/filter/FilterOperator.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/internal/filter/FilterOperator.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/internal/http/interceptor/StreamApiKeyInterceptor.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/internal/http/interceptor/StreamApiKeyInterceptor.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/internal/http/interceptor/StreamAuthInterceptor.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/internal/http/interceptor/StreamAuthInterceptor.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/internal/http/interceptor/StreamClientInfoInterceptor.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/internal/http/interceptor/StreamClientInfoInterceptor.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/internal/http/interceptor/StreamConnectionIdInterceptor.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/internal/http/interceptor/StreamConnectionIdInterceptor.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/internal/http/interceptor/StreamEndpointErrorInterceptor.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/internal/http/interceptor/StreamEndpointErrorInterceptor.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/internal/model/StreamConnectUserDetailsRequest.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/internal/model/StreamConnectUserDetailsRequest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/internal/model/authentication/StreamWSAuthMessageRequest.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/internal/model/authentication/StreamWSAuthMessageRequest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/internal/model/events/ConnectionEvents.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/internal/model/events/ConnectionEvents.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/internal/model/events/StreamHealthCheckEvent.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/internal/model/events/StreamHealthCheckEvent.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/internal/observers/StreamNetworkAndLifeCycleMonitor.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/internal/observers/StreamNetworkAndLifeCycleMonitor.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/internal/observers/StreamNetworkAndLifecycleMonitorImpl.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/internal/observers/StreamNetworkAndLifecycleMonitorImpl.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/internal/observers/StreamNetworkAndLifecycleMonitorListener.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/internal/observers/StreamNetworkAndLifecycleMonitorListener.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/internal/observers/lifecycle/StreamLifecycleMonitorImpl.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/internal/observers/lifecycle/StreamLifecycleMonitorImpl.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/internal/observers/network/StreamNetworkMonitorCallback.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/internal/observers/network/StreamNetworkMonitorCallback.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/internal/observers/network/StreamNetworkMonitorImpl.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/internal/observers/network/StreamNetworkMonitorImpl.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/internal/observers/network/StreamNetworkMonitorUtils.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/internal/observers/network/StreamNetworkMonitorUtils.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/internal/observers/network/StreamNetworkSignalProcessing.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/internal/observers/network/StreamNetworkSignalProcessing.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/internal/observers/network/StreamNetworkSnapshotBuilder.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/internal/observers/network/StreamNetworkSnapshotBuilder.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/internal/processing/StreamBatcherImpl.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/internal/processing/StreamBatcherImpl.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/internal/processing/StreamDebouncerImpl.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/internal/processing/StreamDebouncerImpl.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/internal/processing/StreamRestartableChannel.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/internal/processing/StreamRestartableChannel.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/internal/processing/StreamRetryProcessorImpl.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/internal/processing/StreamRetryProcessorImpl.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/internal/processing/StreamSerialProcessingQueueImpl.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/internal/processing/StreamSerialProcessingQueueImpl.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/internal/processing/StreamSingleFlightProcessorImpl.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/internal/processing/StreamSingleFlightProcessorImpl.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/internal/processing/StreamThrottlerImpl.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/internal/processing/StreamThrottlerImpl.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/internal/recovery/StreamConnectionRecoveryEvaluatorImpl.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/internal/recovery/StreamConnectionRecoveryEvaluatorImpl.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/internal/serialization/StreamClientEventSerializationImpl.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/internal/serialization/StreamClientEventSerializationImpl.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/internal/serialization/StreamCompositeEventSerializationImpl.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/internal/serialization/StreamCompositeEventSerializationImpl.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/internal/serialization/StreamCompositeMoshiJsonSerialization.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/internal/serialization/StreamCompositeMoshiJsonSerialization.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/internal/serialization/StreamMoshiJsonSerializationImpl.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/internal/serialization/StreamMoshiJsonSerializationImpl.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/internal/serialization/moshi/StreamCoreMoshiProvider.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/internal/serialization/moshi/StreamCoreMoshiProvider.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/internal/socket/SocketConstants.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/internal/socket/SocketConstants.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/internal/socket/StreamSocketSession.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/internal/socket/StreamSocketSession.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/internal/socket/StreamWebSocketImpl.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/internal/socket/StreamWebSocketImpl.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/internal/socket/connection/StreamConnectionIdHolderImpl.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/internal/socket/connection/StreamConnectionIdHolderImpl.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/internal/socket/factory/StreamWebSocketFactoryImpl.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/internal/socket/factory/StreamWebSocketFactoryImpl.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/internal/socket/model/ConnectUserData.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/internal/socket/model/ConnectUserData.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/internal/socket/monitor/StreamHealthMonitorImpl.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/internal/socket/monitor/StreamHealthMonitorImpl.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/internal/sort/SortFieldImpl.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/internal/sort/SortFieldImpl.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/internal/subscribe/StreamSubscriptionManagerImpl.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/internal/subscribe/StreamSubscriptionManagerImpl.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/main/java/io/getstream/android/core/internal/watcher/StreamWatcherImpl.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/internal/watcher/StreamWatcherImpl.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/test/java/io/getstream/android/core/api/ApiFactoryTest.kt
+++ b/stream-android-core/src/test/java/io/getstream/android/core/api/ApiFactoryTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/test/java/io/getstream/android/core/api/StreamClientConfigFactoryTest.kt
+++ b/stream-android-core/src/test/java/io/getstream/android/core/api/StreamClientConfigFactoryTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/test/java/io/getstream/android/core/api/StreamClientFactoryTest.kt
+++ b/stream-android-core/src/test/java/io/getstream/android/core/api/StreamClientFactoryTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/test/java/io/getstream/android/core/api/components/StreamAndroidComponentsProviderLatestApiTest.kt
+++ b/stream-android-core/src/test/java/io/getstream/android/core/api/components/StreamAndroidComponentsProviderLatestApiTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/test/java/io/getstream/android/core/api/components/StreamAndroidComponentsProviderLegacyApiTest.kt
+++ b/stream-android-core/src/test/java/io/getstream/android/core/api/components/StreamAndroidComponentsProviderLegacyApiTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/test/java/io/getstream/android/core/api/filter/FilterMatchingTest.kt
+++ b/stream-android-core/src/test/java/io/getstream/android/core/api/filter/FilterMatchingTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/test/java/io/getstream/android/core/api/filter/FilterRobolectricTest.kt
+++ b/stream-android-core/src/test/java/io/getstream/android/core/api/filter/FilterRobolectricTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/test/java/io/getstream/android/core/api/filter/FilterToRequestTest.kt
+++ b/stream-android-core/src/test/java/io/getstream/android/core/api/filter/FilterToRequestTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/test/java/io/getstream/android/core/api/http/StreamOkHttpInterceptorsTest.kt
+++ b/stream-android-core/src/test/java/io/getstream/android/core/api/http/StreamOkHttpInterceptorsTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/test/java/io/getstream/android/core/api/log/StreamLoggerProviderTest.kt
+++ b/stream-android-core/src/test/java/io/getstream/android/core/api/log/StreamLoggerProviderTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/test/java/io/getstream/android/core/api/model/config/StreamClientSerializationConfigTest.kt
+++ b/stream-android-core/src/test/java/io/getstream/android/core/api/model/config/StreamClientSerializationConfigTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/test/java/io/getstream/android/core/api/model/config/StreamSocketConfigTest.kt
+++ b/stream-android-core/src/test/java/io/getstream/android/core/api/model/config/StreamSocketConfigTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/test/java/io/getstream/android/core/api/model/retry/StreamRetryPolicyTest.kt
+++ b/stream-android-core/src/test/java/io/getstream/android/core/api/model/retry/StreamRetryPolicyTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/test/java/io/getstream/android/core/api/model/value/StreamValueClassesTest.kt
+++ b/stream-android-core/src/test/java/io/getstream/android/core/api/model/value/StreamValueClassesTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/test/java/io/getstream/android/core/api/observers/lifecycle/StreamLifecycleMonitorTest.kt
+++ b/stream-android-core/src/test/java/io/getstream/android/core/api/observers/lifecycle/StreamLifecycleMonitorTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/test/java/io/getstream/android/core/api/observers/network/StreamNetworkMonitorFactoryTest.kt
+++ b/stream-android-core/src/test/java/io/getstream/android/core/api/observers/network/StreamNetworkMonitorFactoryTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/test/java/io/getstream/android/core/api/observers/network/StreamNetworkMonitorListenerTest.kt
+++ b/stream-android-core/src/test/java/io/getstream/android/core/api/observers/network/StreamNetworkMonitorListenerTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/test/java/io/getstream/android/core/api/processing/ProcessingFactoryTest.kt
+++ b/stream-android-core/src/test/java/io/getstream/android/core/api/processing/ProcessingFactoryTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/test/java/io/getstream/android/core/api/recovery/StreamConnectionRecoveryEvaluatorFactoryTest.kt
+++ b/stream-android-core/src/test/java/io/getstream/android/core/api/recovery/StreamConnectionRecoveryEvaluatorFactoryTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/test/java/io/getstream/android/core/api/socket/listeners/StreamListenersDefaultImplsTest.kt
+++ b/stream-android-core/src/test/java/io/getstream/android/core/api/socket/listeners/StreamListenersDefaultImplsTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/test/java/io/getstream/android/core/api/sort/SortTest.kt
+++ b/stream-android-core/src/test/java/io/getstream/android/core/api/sort/SortTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/test/java/io/getstream/android/core/api/utils/AlgebraTest.kt
+++ b/stream-android-core/src/test/java/io/getstream/android/core/api/utils/AlgebraTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/test/java/io/getstream/android/core/api/utils/CatchingUtilsTest.kt
+++ b/stream-android-core/src/test/java/io/getstream/android/core/api/utils/CatchingUtilsTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/test/java/io/getstream/android/core/api/utils/FlowsTest.kt
+++ b/stream-android-core/src/test/java/io/getstream/android/core/api/utils/FlowsTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/test/java/io/getstream/android/core/api/utils/MapUtilsTest.kt
+++ b/stream-android-core/src/test/java/io/getstream/android/core/api/utils/MapUtilsTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/test/java/io/getstream/android/core/api/utils/ResponseTest.kt
+++ b/stream-android-core/src/test/java/io/getstream/android/core/api/utils/ResponseTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/test/java/io/getstream/android/core/api/utils/ResultTest.kt
+++ b/stream-android-core/src/test/java/io/getstream/android/core/api/utils/ResultTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/test/java/io/getstream/android/core/api/utils/ThreadingTest.kt
+++ b/stream-android-core/src/test/java/io/getstream/android/core/api/utils/ThreadingTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/test/java/io/getstream/android/core/internal/authentication/StreamTokenManagerImplTest.kt
+++ b/stream-android-core/src/test/java/io/getstream/android/core/internal/authentication/StreamTokenManagerImplTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/test/java/io/getstream/android/core/internal/client/StreamClientIImplTest.kt
+++ b/stream-android-core/src/test/java/io/getstream/android/core/internal/client/StreamClientIImplTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/test/java/io/getstream/android/core/internal/http/StreamHttpClientInfoHeaderTest.kt
+++ b/stream-android-core/src/test/java/io/getstream/android/core/internal/http/StreamHttpClientInfoHeaderTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/test/java/io/getstream/android/core/internal/http/interceptor/StreamApiKeyInterceptorTest.kt
+++ b/stream-android-core/src/test/java/io/getstream/android/core/internal/http/interceptor/StreamApiKeyInterceptorTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/test/java/io/getstream/android/core/internal/http/interceptor/StreamAuthInterceptorTest.kt
+++ b/stream-android-core/src/test/java/io/getstream/android/core/internal/http/interceptor/StreamAuthInterceptorTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/test/java/io/getstream/android/core/internal/http/interceptor/StreamClientInfoInterceptorTest.kt
+++ b/stream-android-core/src/test/java/io/getstream/android/core/internal/http/interceptor/StreamClientInfoInterceptorTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/test/java/io/getstream/android/core/internal/http/interceptor/StreamConnectionIdInterceptorTest.kt
+++ b/stream-android-core/src/test/java/io/getstream/android/core/internal/http/interceptor/StreamConnectionIdInterceptorTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/test/java/io/getstream/android/core/internal/http/interceptor/StreamEndpointErrorInterceptorTest.kt
+++ b/stream-android-core/src/test/java/io/getstream/android/core/internal/http/interceptor/StreamEndpointErrorInterceptorTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/test/java/io/getstream/android/core/internal/model/StreamInternalModelSerializationTest.kt
+++ b/stream-android-core/src/test/java/io/getstream/android/core/internal/model/StreamInternalModelSerializationTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/test/java/io/getstream/android/core/internal/observers/StreamNetworkAndLifecycleMonitorImplTest.kt
+++ b/stream-android-core/src/test/java/io/getstream/android/core/internal/observers/StreamNetworkAndLifecycleMonitorImplTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/test/java/io/getstream/android/core/internal/observers/network/StreamNetworkMonitorCallbackTest.kt
+++ b/stream-android-core/src/test/java/io/getstream/android/core/internal/observers/network/StreamNetworkMonitorCallbackTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/test/java/io/getstream/android/core/internal/observers/network/StreamNetworkMonitorImplTest.kt
+++ b/stream-android-core/src/test/java/io/getstream/android/core/internal/observers/network/StreamNetworkMonitorImplTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/test/java/io/getstream/android/core/internal/observers/network/StreamNetworkMonitorUtilsTest.kt
+++ b/stream-android-core/src/test/java/io/getstream/android/core/internal/observers/network/StreamNetworkMonitorUtilsTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/test/java/io/getstream/android/core/internal/observers/network/StreamNetworkSignalProcessingLatestApiTest.kt
+++ b/stream-android-core/src/test/java/io/getstream/android/core/internal/observers/network/StreamNetworkSignalProcessingLatestApiTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/test/java/io/getstream/android/core/internal/observers/network/StreamNetworkSignalProcessingLegacyApiTest.kt
+++ b/stream-android-core/src/test/java/io/getstream/android/core/internal/observers/network/StreamNetworkSignalProcessingLegacyApiTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/test/java/io/getstream/android/core/internal/observers/network/StreamNetworkSignalProcessingTest.kt
+++ b/stream-android-core/src/test/java/io/getstream/android/core/internal/observers/network/StreamNetworkSignalProcessingTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/test/java/io/getstream/android/core/internal/observers/network/StreamNetworkSnapshotBuilderLatestApiTest.kt
+++ b/stream-android-core/src/test/java/io/getstream/android/core/internal/observers/network/StreamNetworkSnapshotBuilderLatestApiTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/test/java/io/getstream/android/core/internal/observers/network/StreamNetworkSnapshotBuilderLegacyApiTest.kt
+++ b/stream-android-core/src/test/java/io/getstream/android/core/internal/observers/network/StreamNetworkSnapshotBuilderLegacyApiTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/test/java/io/getstream/android/core/internal/processing/StreamBatcherImplTest.kt
+++ b/stream-android-core/src/test/java/io/getstream/android/core/internal/processing/StreamBatcherImplTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/test/java/io/getstream/android/core/internal/processing/StreamDebouncerImplTest.kt
+++ b/stream-android-core/src/test/java/io/getstream/android/core/internal/processing/StreamDebouncerImplTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/test/java/io/getstream/android/core/internal/processing/StreamRestartableChannelTest.kt
+++ b/stream-android-core/src/test/java/io/getstream/android/core/internal/processing/StreamRestartableChannelTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/test/java/io/getstream/android/core/internal/processing/StreamRetryProcessorImplTest.kt
+++ b/stream-android-core/src/test/java/io/getstream/android/core/internal/processing/StreamRetryProcessorImplTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/test/java/io/getstream/android/core/internal/processing/StreamSerialProcessingQueueImplTest.kt
+++ b/stream-android-core/src/test/java/io/getstream/android/core/internal/processing/StreamSerialProcessingQueueImplTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/test/java/io/getstream/android/core/internal/processing/StreamSingleFlightProcessorImplTest.kt
+++ b/stream-android-core/src/test/java/io/getstream/android/core/internal/processing/StreamSingleFlightProcessorImplTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/test/java/io/getstream/android/core/internal/processing/StreamThrottlerImplTest.kt
+++ b/stream-android-core/src/test/java/io/getstream/android/core/internal/processing/StreamThrottlerImplTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/test/java/io/getstream/android/core/internal/recovery/StreamConnectionRecoveryEvaluatorImplTest.kt
+++ b/stream-android-core/src/test/java/io/getstream/android/core/internal/recovery/StreamConnectionRecoveryEvaluatorImplTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/test/java/io/getstream/android/core/internal/serialization/StreamClientEventSerializationImplTest.kt
+++ b/stream-android-core/src/test/java/io/getstream/android/core/internal/serialization/StreamClientEventSerializationImplTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/test/java/io/getstream/android/core/internal/serialization/StreamCompositeEventSerializationImplTest.kt
+++ b/stream-android-core/src/test/java/io/getstream/android/core/internal/serialization/StreamCompositeEventSerializationImplTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/test/java/io/getstream/android/core/internal/serialization/StreamCompositeMoshiJsonSerializationTest.kt
+++ b/stream-android-core/src/test/java/io/getstream/android/core/internal/serialization/StreamCompositeMoshiJsonSerializationTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/test/java/io/getstream/android/core/internal/serialization/StreamMoshiJsonSerializationImplTest.kt
+++ b/stream-android-core/src/test/java/io/getstream/android/core/internal/serialization/StreamMoshiJsonSerializationImplTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/test/java/io/getstream/android/core/internal/serialization/moshi/MoshiProviderTest.kt
+++ b/stream-android-core/src/test/java/io/getstream/android/core/internal/serialization/moshi/MoshiProviderTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/test/java/io/getstream/android/core/internal/socket/StreamSocketSessionTest.kt
+++ b/stream-android-core/src/test/java/io/getstream/android/core/internal/socket/StreamSocketSessionTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/test/java/io/getstream/android/core/internal/socket/StreamWebSocketImplTest.kt
+++ b/stream-android-core/src/test/java/io/getstream/android/core/internal/socket/StreamWebSocketImplTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/test/java/io/getstream/android/core/internal/socket/connection/StreamConnectionIdHolderImplTest.kt
+++ b/stream-android-core/src/test/java/io/getstream/android/core/internal/socket/connection/StreamConnectionIdHolderImplTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/test/java/io/getstream/android/core/internal/socket/factory/StreamWebSocketFactoryImplTest.kt
+++ b/stream-android-core/src/test/java/io/getstream/android/core/internal/socket/factory/StreamWebSocketFactoryImplTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/test/java/io/getstream/android/core/internal/socket/monitor/StreamHealthMonitorImplTest.kt
+++ b/stream-android-core/src/test/java/io/getstream/android/core/internal/socket/monitor/StreamHealthMonitorImplTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/test/java/io/getstream/android/core/internal/subscribe/StreamSubscriptionManagerImplTest.kt
+++ b/stream-android-core/src/test/java/io/getstream/android/core/internal/subscribe/StreamSubscriptionManagerImplTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/test/java/io/getstream/android/core/internal/watcher/StreamWatcherImplTest.kt
+++ b/stream-android-core/src/test/java/io/getstream/android/core/internal/watcher/StreamWatcherImplTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/test/java/io/getstream/android/core/testing/TestLogger.kt
+++ b/stream-android-core/src/test/java/io/getstream/android/core/testing/TestLogger.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/test/java/io/getstream/android/core/testutil/ReflectionAssertions.kt
+++ b/stream-android-core/src/test/java/io/getstream/android/core/testutil/ReflectionAssertions.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.

--- a/stream-android-core/src/test/java/io/getstream/android/core/utils/ValueClassTestUtils.kt
+++ b/stream-android-core/src/test/java/io/getstream/android/core/utils/ValueClassTestUtils.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
  *
  * Licensed under the Stream License;
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
### Goal

Bump the Stream Android build conventions Gradle plugin from v0.5.0 to v0.10.0 to align with the CI workflows already on v0.10.0 (PR #52).

### Implementation

- Bumped `streamConventions` in `gradle/libs.versions.toml` from 0.5.0 to 0.10.0
- Spotless reformatted all files: copyright header year 2025 → 2026 (mechanical)

### Testing

- `./gradlew spotlessApply` runs clean
- Build verified locally