### PR TITLE
Move `StreamThrottlePolicy` to model package

### DIFF
--- a/stream-android-core/src/main/java/io/getstream/android/core/api/model/processing/StreamThrottlePolicy.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/api/model/processing/StreamThrottlePolicy.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.getstream.android.core.api.processing
+package io.getstream.android.core.api.model.processing
 
 import io.getstream.android.core.annotations.StreamInternalApi
 

--- a/stream-android-core/src/main/java/io/getstream/android/core/api/processing/StreamThrottler.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/api/processing/StreamThrottler.kt
@@ -18,6 +18,7 @@ package io.getstream.android.core.api.processing
 
 import io.getstream.android.core.annotations.StreamInternalApi
 import io.getstream.android.core.api.log.StreamLogger
+import io.getstream.android.core.api.model.processing.StreamThrottlePolicy
 import io.getstream.android.core.internal.processing.StreamThrottlerImpl
 import kotlinx.coroutines.CoroutineScope
 

--- a/stream-android-core/src/main/java/io/getstream/android/core/internal/processing/StreamThrottlerImpl.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/internal/processing/StreamThrottlerImpl.kt
@@ -17,7 +17,7 @@
 package io.getstream.android.core.internal.processing
 
 import io.getstream.android.core.api.log.StreamLogger
-import io.getstream.android.core.api.processing.StreamThrottlePolicy
+import io.getstream.android.core.api.model.processing.StreamThrottlePolicy
 import io.getstream.android.core.api.processing.StreamThrottler
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicReference

--- a/stream-android-core/src/test/java/io/getstream/android/core/api/processing/ProcessingFactoryTest.kt
+++ b/stream-android-core/src/test/java/io/getstream/android/core/api/processing/ProcessingFactoryTest.kt
@@ -19,6 +19,7 @@
 package io.getstream.android.core.api.processing
 
 import io.getstream.android.core.api.model.StreamTypedKey.Companion.asStreamTypedKey
+import io.getstream.android.core.api.model.processing.StreamThrottlePolicy
 import io.getstream.android.core.api.model.retry.StreamRetryPolicy
 import io.mockk.mockk
 import kotlinx.coroutines.CoroutineScope

--- a/stream-android-core/src/test/java/io/getstream/android/core/internal/processing/StreamThrottlerImplTest.kt
+++ b/stream-android-core/src/test/java/io/getstream/android/core/internal/processing/StreamThrottlerImplTest.kt
@@ -18,7 +18,7 @@
 
 package io.getstream.android.core.internal.processing
 
-import io.getstream.android.core.api.processing.StreamThrottlePolicy
+import io.getstream.android.core.api.model.processing.StreamThrottlePolicy
 import io.mockk.mockk
 import kotlin.test.assertFailsWith
 import kotlinx.coroutines.CoroutineExceptionHandler


### PR DESCRIPTION
### Goal

Separate the policy data model from the interface definition by relocating `StreamThrottlePolicy` from `api.processing` to `api.model.processing`, consistent with other model types (`retry`, `config`).

### Implementation

- Moved `StreamThrottlePolicy.kt` from `api/processing/` to `api/model/processing/`
- Updated imports in `StreamThrottler.kt`, `StreamThrottlerImpl.kt`, `StreamThrottlerImplTest.kt`, and `ProcessingFactoryTest.kt`

### Testing

- All existing throttler tests pass
- Build compiles clean

pr: refactor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code organization and package structure adjustments to improve maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->