### PR TITLE
Bump build conventions to v0.11.0

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   android-ci:
-    uses: GetStream/stream-build-conventions-android/.github/workflows/android-ci.yml@v0.10.0
+    uses: GetStream/stream-build-conventions-android/.github/workflows/android-ci.yml@v0.11.0
     secrets: inherit
     with:
       api-check: false

--- a/.github/workflows/pr-clean-stale.yaml
+++ b/.github/workflows/pr-clean-stale.yaml
@@ -12,5 +12,5 @@ permissions:
 
 jobs:
   pr-clean-stale:
-    uses: GetStream/stream-build-conventions-android/.github/workflows/pr-clean-stale.yaml@v0.10.0
+    uses: GetStream/stream-build-conventions-android/.github/workflows/pr-clean-stale.yaml@v0.11.0
     secrets: inherit

--- a/.github/workflows/pr-quality.yml
+++ b/.github/workflows/pr-quality.yml
@@ -15,5 +15,5 @@ concurrency:
 
 jobs:
   pr-checklist:
-    uses: GetStream/stream-build-conventions-android/.github/workflows/pr-quality.yml@v0.10.0
+    uses: GetStream/stream-build-conventions-android/.github/workflows/pr-quality.yml@v0.11.0
     secrets: inherit

--- a/.github/workflows/publish-new-version.yml
+++ b/.github/workflows/publish-new-version.yml
@@ -30,7 +30,7 @@ jobs:
     permissions:
       contents: write
     needs: pre_release_check
-    uses: GetStream/stream-build-conventions-android/.github/workflows/release.yml@v0.10.0
+    uses: GetStream/stream-build-conventions-android/.github/workflows/release.yml@v0.11.0
     with:
       bump: ${{ inputs.bump }}
     secrets:

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -26,7 +26,7 @@ retrofit = "3.0.0"
 ksp = "2.2.0-2.0.2"
 robolectric = "4.15.1"
 detekt = "1.23.8"
-streamConventions = "0.10.0"
+streamConventions = "0.11.0"
 annotationJvm = "1.9.1"
 
 [libraries]


### PR DESCRIPTION
### Goal

Pick up `stream-build-conventions-android` v0.11.0.

### Implementation

- `gradle/libs.versions.toml`: `streamConventions` 0.10.0 → 0.11.0
- Workflow refs bumped `@v0.10.0` → `@v0.11.0` in:
  - `.github/workflows/android.yml`
  - `.github/workflows/pr-clean-stale.yaml`
  - `.github/workflows/pr-quality.yml`
  - `.github/workflows/publish-new-version.yml`

### Release notes since v0.10.0

- **v0.11.0** — Make release workflow more resilient (GetStream/stream-build-conventions-android#22). Workflow-only.

### Testing

- [ ] CI green
- [ ] `./gradlew help` applies plugins locally