### PR TITLE
Add dependabot configuration to bump Stream conventions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily
+    labels:
+      - "pr:ci"
+
+  - package-ecosystem: gradle
+    directory: /
+    schedule:
+      interval: daily
+    labels:
+      - "pr:ci"
+    allow:
+      - dependency-name: "io.getstream.project"
+      - dependency-name: "io.getstream.android.library"
+      - dependency-name: "io.getstream.android.application"
+      - dependency-name: "io.getstream.android.test"
+      - dependency-name: "io.getstream.java.library"
+      - dependency-name: "io.getstream.java.platform"
+      - dependency-name: "io.getstream.publish"


### PR DESCRIPTION
### Goal

Add dependabot configuration so that PRs bumping Stream conventions will be created automatically by dependabot.

### Implementation

Add `.github/dependabot.yml` with configuration to only update workflows/actions & stream plugins

### Testing

We'll enable dependabot in the repo settings & check that PRs are opened properly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated dependency update configuration for GitHub Actions and build dependencies, enabling daily update checks and automated pull request generation for managed project artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->