### PR TITLE
Accept RFC3339 date strings on internal WS events

### DIFF
--- a/stream-android-core/src/main/java/io/getstream/android/core/internal/serialization/moshi/StreamCoreMoshiProvider.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/internal/serialization/moshi/StreamCoreMoshiProvider.kt
@@ -16,10 +16,13 @@
 
 package io.getstream.android.core.internal.serialization.moshi
 
-import com.squareup.moshi.FromJson
+import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.JsonDataException
+import com.squareup.moshi.JsonReader
+import com.squareup.moshi.JsonWriter
 import com.squareup.moshi.Moshi
-import com.squareup.moshi.ToJson
 import com.squareup.moshi.adapters.PolymorphicJsonAdapterFactory
+import com.squareup.moshi.adapters.Rfc3339DateJsonAdapter
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import io.getstream.android.core.api.model.event.StreamClientWsEvent
 import io.getstream.android.core.internal.model.events.StreamClientConnectedEvent
@@ -28,10 +31,32 @@ import io.getstream.android.core.internal.model.events.StreamHealthCheckEvent
 import java.util.Date
 
 internal class StreamCoreMoshiProvider {
-    object DateMillisAdapter {
-        @ToJson fun toJson(value: Date?): Long? = value?.time
+    /**
+     * Adapter for [Date] fields on internal WS events.
+     *
+     * Writes epoch millis, so the wire format of outbound messages is unchanged. Reads leniently:
+     * gateways send dates either as epoch millis (number) or as RFC3339/ISO-8601 strings — e.g. the
+     * video coordinator's `connection.ok` carries `"created_at": "2026-07-06T07:47:26.592958Z"` at
+     * `$.me.created_at` — so both encodings are accepted.
+     */
+    object LenientDateAdapter : JsonAdapter<Date>() {
+        private val rfc3339 = Rfc3339DateJsonAdapter()
 
-        @FromJson fun fromJson(value: Long?): Date? = value?.let { Date(it) }
+        override fun fromJson(reader: JsonReader): Date? =
+            when (reader.peek()) {
+                JsonReader.Token.NULL -> reader.nextNull()
+                JsonReader.Token.NUMBER -> Date(reader.nextLong())
+                JsonReader.Token.STRING -> rfc3339.fromJson(reader)
+                else ->
+                    throw JsonDataException(
+                        "Expected a date as epoch millis or an RFC3339 string " +
+                            "but was ${reader.peek()} at path ${reader.path}"
+                    )
+            }
+
+        override fun toJson(writer: JsonWriter, value: Date?) {
+            writer.value(value?.time)
+        }
     }
 
     fun builder(configure: (Moshi.Builder) -> Unit): Moshi.Builder {
@@ -40,7 +65,7 @@ internal class StreamCoreMoshiProvider {
         val moshiBuilder =
             builder.apply {
                 add(KotlinJsonAdapterFactory())
-                add(DateMillisAdapter)
+                add(Date::class.java, LenientDateAdapter)
                 add(
                     PolymorphicJsonAdapterFactory.of(StreamClientWsEvent::class.java, "type")
                         .withSubtype(StreamClientConnectedEvent::class.java, "connection.ok")

--- a/stream-android-core/src/test/java/io/getstream/android/core/internal/serialization/moshi/MoshiProviderTest.kt
+++ b/stream-android-core/src/test/java/io/getstream/android/core/internal/serialization/moshi/MoshiProviderTest.kt
@@ -130,26 +130,33 @@ class MoshiProviderTest {
     @Test
     fun `toJson returns millis for non-null Date`() {
         val date = Date(1734567890000L)
-        val millis = StreamCoreMoshiProvider.DateMillisAdapter.toJson(date)
-        assertEquals(1734567890000L, millis)
+        val json = StreamCoreMoshiProvider.LenientDateAdapter.toJson(date)
+        assertEquals("1734567890000", json)
     }
 
     @Test
     fun `toJson returns null for null Date`() {
-        val millis = StreamCoreMoshiProvider.DateMillisAdapter.toJson(null)
-        assertNull(millis)
+        val json = StreamCoreMoshiProvider.LenientDateAdapter.toJson(null)
+        assertEquals("null", json)
     }
 
     @Test
     fun `fromJson returns Date for non-null millis`() {
         val millis = 1734567890000L
-        val date = StreamCoreMoshiProvider.DateMillisAdapter.fromJson(millis)
+        val date = StreamCoreMoshiProvider.LenientDateAdapter.fromJson("$millis")
         assertEquals(Date(millis), date)
     }
 
     @Test
     fun `fromJson returns null for null millis`() {
-        val date = StreamCoreMoshiProvider.DateMillisAdapter.fromJson(null)
+        val date = StreamCoreMoshiProvider.LenientDateAdapter.fromJson("null")
         assertNull(date)
+    }
+
+    @Test
+    fun `fromJson returns Date for RFC3339 string`() {
+        val date =
+            StreamCoreMoshiProvider.LenientDateAdapter.fromJson("\"2024-12-19T00:24:50.000Z\"")
+        assertEquals(Date(1734567890000L), date)
     }
 }

--- a/stream-android-core/src/test/java/io/getstream/android/core/internal/serialization/moshi/StreamCoreMoshiProviderDateParsingTest.kt
+++ b/stream-android-core/src/test/java/io/getstream/android/core/internal/serialization/moshi/StreamCoreMoshiProviderDateParsingTest.kt
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-core-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.android.core.internal.serialization.moshi
+
+import com.squareup.moshi.JsonDataException
+import io.getstream.android.core.api.model.connection.StreamConnectedUser
+import io.getstream.android.core.api.model.event.StreamClientWsEvent
+import io.getstream.android.core.internal.model.events.StreamClientConnectedEvent
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import java.util.TimeZone
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import org.junit.Test
+
+internal class StreamCoreMoshiProviderDateParsingTest {
+
+    private val moshi = StreamCoreMoshiProvider().builder {}.build()
+
+    @Test
+    fun `connection ok with RFC3339 date strings parses`() {
+        // Given: a connection.ok frame as sent by the video coordinator (captured from a real
+        // handshake) — all date fields are RFC3339 strings, not epoch millis.
+        val adapter = moshi.adapter(StreamClientWsEvent::class.java)
+        val raw =
+            """
+            {"type":"connection.ok","created_at":"2026-07-06T07:47:26.660610521Z",
+            "connection_id":"6a397f9d-0a1d-27b1-0200-000002b8ca27",
+            "me":{"id":"2T16C16M","name":"2T16C16M","image":"","custom":{"email":"2T16C16M"},
+            "language":"","role":"user","teams":[],
+            "created_at":"2026-07-06T07:47:26.592958Z",
+            "updated_at":"2026-07-06T07:47:26.656029Z",
+            "banned":false,"online":true,
+            "last_active":"2026-07-06T07:47:26.592958Z",
+            "devices":[],"invisible":false,"mutes":[],"channel_mutes":[],
+            "unread_count":0,"total_unread_count":0,"unread_channels":0,"unread_threads":0}}
+            """
+                .trimIndent()
+
+        // When
+        val event = adapter.fromJson(raw)
+
+        // Then
+        assertTrue(event is StreamClientConnectedEvent)
+        assertEquals("6a397f9d-0a1d-27b1-0200-000002b8ca27", event.connectionId)
+        assertEquals("2T16C16M", event.me.id)
+        assertEquals(utcDate("2026-07-06T07:47:26.592"), event.me.createdAt)
+        assertEquals(utcDate("2026-07-06T07:47:26.656"), event.me.updatedAt)
+        assertEquals(utcDate("2026-07-06T07:47:26.592"), event.me.lastActive)
+    }
+
+    @Test
+    fun `connection ok with epoch millis dates still parses`() {
+        // Given: the pre-existing wire format — dates as epoch millis.
+        val adapter = moshi.adapter(StreamClientWsEvent::class.java)
+        val millis = 1_783_064_846_592L
+        val raw =
+            """
+            {"type":"connection.ok","connection_id":"conn-1",
+            "me":{"id":"u1","language":"en","role":"user","teams":[],
+            "created_at":$millis,"updated_at":$millis}}
+            """
+                .trimIndent()
+
+        // When
+        val event = adapter.fromJson(raw)
+
+        // Then
+        assertTrue(event is StreamClientConnectedEvent)
+        assertEquals(Date(millis), event.me.createdAt)
+        assertEquals(Date(millis), event.me.updatedAt)
+    }
+
+    @Test
+    fun `dates serialize as epoch millis`() {
+        // Given
+        val adapter = moshi.adapter(StreamConnectedUser::class.java)
+        val user =
+            StreamConnectedUser(
+                createdAt = Date(1000),
+                id = "u",
+                language = "en",
+                role = "user",
+                updatedAt = Date(2000),
+                teams = emptyList(),
+            )
+
+        // When
+        val json = adapter.toJson(user)
+
+        // Then: outbound wire format is unchanged.
+        assertTrue(json.contains("\"created_at\":1000"))
+        assertTrue(json.contains("\"updated_at\":2000"))
+    }
+
+    @Test
+    fun `RFC3339 date round-trips through millis`() {
+        // Given
+        val adapter = moshi.adapter(Date::class.java)
+        val parsed = adapter.fromJson("\"2026-07-06T07:47:26.592Z\"")
+
+        // When
+        val json = adapter.toJson(parsed)
+        val reparsed = adapter.fromJson(json)
+
+        // Then
+        assertNotNull(parsed)
+        assertEquals(parsed, reparsed)
+    }
+
+    @Test(expected = JsonDataException::class)
+    fun `unsupported date token throws`() {
+        // Given
+        val adapter = moshi.adapter(Date::class.java)
+
+        // When
+        adapter.fromJson("true")
+
+        // Then expect exception
+    }
+
+    private fun utcDate(isoMillisPrecision: String): Date =
+        SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS", Locale.US)
+            .apply { timeZone = TimeZone.getTimeZone("UTC") }
+            .parse(isoMillisPrecision)!!
+}


### PR DESCRIPTION
### Goal

Fixes [AND-1295](https://linear.app/stream/issue/AND-1295/core-ws-date-parsing-rejects-rfc3339-video-coordinator-cant-connect) — `StreamClient.connect()` fails permanently against the video coordinator: the gateway sends dates as RFC3339 strings, but the internal Moshi's `DateMillisAdapter` only accepts epoch millis. The `connection.ok` handshake parse throws (`Expected a long but was 2026-07-06T07:47:26.592958Z at path $.me.created_at`), the composite serializer falls back to a null external serializer (`No external serializer available`), and the socket loops `Opening → Authenticating → Disconnected` forever. Not fixable product-side: `StreamClientConnectedEvent` is internal and `StreamSocketSession` type-matches on it.

### Implementation

- Replaced `DateMillisAdapter` with `LenientDateAdapter` in `StreamCoreMoshiProvider`: reads accept both epoch-millis numbers and RFC3339 strings (delegating to Moshi's `Rfc3339DateJsonAdapter`, already a dependency); writes stay epoch millis, so the outbound wire format is unchanged.
- No public API change — the provider is `internal`. Millis payloads parse identically to 5.0.0; only previously-failing string payloads gain a successful parse, so existing consumers (Feeds) are unaffected. Safe as a **5.0.1** patch.

### Testing

- New `StreamCoreMoshiProviderDateParsingTest`: parses the real `connection.ok` frame captured from the video coordinator handshake (RFC3339, sub-millisecond precision), epoch-millis backward-compat, millis-on-write assertion, round-trip, invalid-token failure.
- Full `:stream-android-core:testDebugUnitTest`: 731 tests, 730 green — the 1 failure (`StreamCompositeEventSerializationImplTest`, reflection on `declaredConstructors.first()`) fails identically on clean `develop`; pre-existing flake, unrelated.
- Root cause reproduced end-to-end on an emulator with the video SDK Phase-2 stack before the fix.

### Checklist
- [x] Issue linked (if any)
- [x] Tests/docs updated
- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required for external contributors)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved date handling for real-time event data so timestamps can now be read from either numeric epoch values or standard ISO/RFC 3339 strings.
  * Outbound date formatting remains consistent, preserving the existing timestamp format sent by the app.
  * Added clearer error handling when date values are malformed or in an unexpected format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->