### PR TITLE
Prevent single-flight double-execution when a caller is cancelled

### DIFF
--- a/stream-android-core/src/main/java/io/getstream/android/core/internal/processing/StreamSingleFlightProcessorImpl.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/internal/processing/StreamSingleFlightProcessorImpl.kt
@@ -71,6 +71,10 @@ internal class StreamSingleFlightProcessorImpl(
         val existing = flights.putIfAbsent(key, newExecution)
         val job =
             if (existing != null) {
+                // We lost the race. `scope.async` attached this LAZY deferred to `scope`'s Job
+                // at construction, so leaving it unstarted keeps an inert child (holding `block`
+                // and its captures) attached for the scope's lifetime. Cancel to detach it.
+                newExecution.cancel()
                 existing
             } else {
                 // Evict on completion of the shared work itself, never from an awaiting

--- a/stream-android-core/src/main/java/io/getstream/android/core/internal/processing/StreamSingleFlightProcessorImpl.kt
+++ b/stream-android-core/src/main/java/io/getstream/android/core/internal/processing/StreamSingleFlightProcessorImpl.kt
@@ -69,15 +69,23 @@ internal class StreamSingleFlightProcessorImpl(
 
         // Install ours or join the winner
         val existing = flights.putIfAbsent(key, newExecution)
-        val job = existing ?: newExecution.also { it.start() }
+        val job =
+            if (existing != null) {
+                existing
+            } else {
+                // Evict on completion of the shared work itself, never from an awaiting
+                // caller's frame. The work is detached in [scope], so a cancelled installer
+                // whose finally removed the entry would leave the job still running while the
+                // map went empty — the next caller for this key would miss and start a second
+                // execution. Conditional remove leaves any newer flight that replaced us intact.
+                newExecution.invokeOnCompletion { flights.remove(key, newExecution) }
+                newExecution.also { it.start() }
+            }
 
         return try {
             job.await() as Result<T>
         } catch (t: Throwable) {
             Result.failure(t)
-        } finally {
-            // Remove only if this exact job is still mapped
-            flights.remove(key, job)
         }
     }
 

--- a/stream-android-core/src/test/java/io/getstream/android/core/internal/processing/StreamSingleFlightProcessorImplTest.kt
+++ b/stream-android-core/src/test/java/io/getstream/android/core/internal/processing/StreamSingleFlightProcessorImplTest.kt
@@ -199,6 +199,109 @@ class StreamSingleFlightProcessorImplTest {
     }
 
     @Test
+    fun `installer cancellation must not orphan the flight and cause a re-run`() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val scope = CoroutineScope(SupervisorJob() + dispatcher)
+        val singleFlight = StreamSingleFlightProcessorImpl(scope)
+
+        val worker = mockk<Worker>()
+        coEvery { worker.workSlow() } coAnswers
+            {
+                delay(1_000)
+                99
+            }
+
+        val key = "k".asStreamTypedKey<Int>()
+
+        // Installer takes the slow path: it is the caller whose finally evicts the map entry.
+        val installer = async { singleFlight.run(key) { worker.workSlow() } }
+        testScheduler.runCurrent()
+        // Follower takes the fast path and attaches to the same running deferred.
+        val follower = async { singleFlight.run(key) { worker.workSlow() } }
+        testScheduler.runCurrent()
+
+        // Cancel the INSTALLER before the shared work completes. Its finally runs
+        // flights.remove(key, job) while the job is still alive in `scope`.
+        installer.cancel(CancellationException("nav away"))
+        testScheduler.runCurrent()
+
+        // A new caller arriving after the eviction window must still coalesce onto the
+        // in-flight job, not start a second execution.
+        val late = async { singleFlight.run(key) { worker.workSlow() } }
+        advanceUntilIdle()
+
+        // Follower is still served by the orphaned-but-running job.
+        assertEquals(99, follower.await().getOrThrow())
+        assertEquals(99, late.await().getOrThrow())
+
+        // The shared block must have run exactly once for all callers.
+        coVerify(exactly = 1) { worker.workSlow() }
+    }
+
+    @Test
+    fun `coalescing holds for a newcomer even after all current awaiters are cancelled`() =
+        runTest {
+            val dispatcher = StandardTestDispatcher(testScheduler)
+            val scope = CoroutineScope(SupervisorJob() + dispatcher)
+            val singleFlight = StreamSingleFlightProcessorImpl(scope)
+
+            val worker = mockk<Worker>()
+            coEvery { worker.workSlow() } coAnswers
+                {
+                    delay(1_000)
+                    99
+                }
+
+            val key = "k".asStreamTypedKey<Int>()
+
+            val installer = async { singleFlight.run(key) { worker.workSlow() } }
+            testScheduler.runCurrent()
+            val follower = async { singleFlight.run(key) { worker.workSlow() } }
+            testScheduler.runCurrent()
+
+            // Every current awaiter goes away, but the detached job keeps running in [scope].
+            installer.cancel(CancellationException("gone"))
+            follower.cancel(CancellationException("gone"))
+            testScheduler.runCurrent()
+
+            // A newcomer arriving during the in-flight window must join the running job.
+            val late = async { singleFlight.run(key) { worker.workSlow() } }
+            advanceUntilIdle()
+
+            assertEquals(99, late.await().getOrThrow())
+            coVerify(exactly = 1) { worker.workSlow() }
+        }
+
+    @Test
+    fun `a run after the previous flight completed starts a fresh execution`() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val scope = CoroutineScope(SupervisorJob() + dispatcher)
+        val singleFlight = StreamSingleFlightProcessorImpl(scope)
+
+        val worker = mockk<Worker>()
+        coEvery { worker.workInt() } coAnswers
+            {
+                delay(1_000)
+                7
+            }
+
+        val key = "k".asStreamTypedKey<Int>()
+
+        val first = async { singleFlight.run(key) { worker.workInt() } }
+        advanceUntilIdle()
+        assertEquals(7, first.await().getOrThrow())
+
+        // A completed flight must be evicted, never replayed: the next call re-executes.
+        assertFalse(singleFlight.has(key))
+
+        val second = async { singleFlight.run(key) { worker.workInt() } }
+        advanceUntilIdle()
+        assertEquals(7, second.await().getOrThrow())
+
+        coVerify(exactly = 2) { worker.workInt() }
+    }
+
+    @Test
     fun `cancel(key) cancels in-flight and joiners see failure`() = runTest {
         val dispatcher = StandardTestDispatcher(testScheduler)
         val scope = CoroutineScope(SupervisorJob() + dispatcher)

--- a/stream-android-core/src/test/java/io/getstream/android/core/internal/processing/StreamSingleFlightProcessorImplTest.kt
+++ b/stream-android-core/src/test/java/io/getstream/android/core/internal/processing/StreamSingleFlightProcessorImplTest.kt
@@ -213,24 +213,26 @@ class StreamSingleFlightProcessorImplTest {
 
         val key = "k".asStreamTypedKey<Int>()
 
-        // Installer takes the slow path: it is the caller whose finally evicts the map entry.
+        // Installer takes the slow path — the only caller that ever carried the eviction.
+        // Before completion-based eviction, cancelling it ran flights.remove(key, job) in its
+        // finally while the shared job kept running in `scope`, so a later caller for the same
+        // key missed the map and re-executed. This test guards against that regression.
         val installer = async { singleFlight.run(key) { worker.workSlow() } }
         testScheduler.runCurrent()
         // Follower takes the fast path and attaches to the same running deferred.
         val follower = async { singleFlight.run(key) { worker.workSlow() } }
         testScheduler.runCurrent()
 
-        // Cancel the INSTALLER before the shared work completes. Its finally runs
-        // flights.remove(key, job) while the job is still alive in `scope`.
+        // Cancel the installer before the shared work completes.
         installer.cancel(CancellationException("nav away"))
         testScheduler.runCurrent()
 
-        // A new caller arriving after the eviction window must still coalesce onto the
+        // A newcomer arriving after the (former) eviction window must still coalesce onto the
         // in-flight job, not start a second execution.
         val late = async { singleFlight.run(key) { worker.workSlow() } }
         advanceUntilIdle()
 
-        // Follower is still served by the orphaned-but-running job.
+        // Every caller is served by the one shared job.
         assertEquals(99, follower.await().getOrThrow())
         assertEquals(99, late.await().getOrThrow())
 

--- a/stream-android-core/src/test/java/io/getstream/android/core/internal/processing/StreamSingleFlightProcessorImplTest.kt
+++ b/stream-android-core/src/test/java/io/getstream/android/core/internal/processing/StreamSingleFlightProcessorImplTest.kt
@@ -57,6 +57,17 @@ class StreamSingleFlightProcessorImplTest {
         }
     }
 
+    // Reports every key absent on get() (forces the slow path, so run() builds a newExecution)
+    // but returns a preset winner from putIfAbsent() (forces the loser branch) — reproduces the
+    // putIfAbsent race deterministically, without real threads.
+    class RacyLoserMap(private val winner: Deferred<Result<*>>) :
+        ConcurrentMap<Any, Deferred<Result<*>>> by ConcurrentHashMap() {
+        override fun get(key: Any): Deferred<Result<*>>? = null
+
+        override fun putIfAbsent(key: Any, value: Deferred<Result<*>>): Deferred<Result<*>>? =
+            winner
+    }
+
     // Simple collaborator with a suspend function we can verify
     private interface Worker {
         suspend fun workInt(): Int
@@ -565,6 +576,28 @@ class StreamSingleFlightProcessorImplTest {
         } finally {
             pool.close() // or pool.executor.shutdown()
         }
+    }
+
+    @Test
+    fun `race loser cancels its unstarted deferred so it does not leak into the scope`() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val parent = SupervisorJob()
+        val scope = CoroutineScope(parent + dispatcher)
+
+        // A winner already in flight for this key; the caller below will lose the race to it.
+        val winner = CompletableDeferred<Result<*>>()
+        val singleFlight = StreamSingleFlightProcessorImpl(scope, RacyLoserMap(winner))
+
+        val childrenBefore = parent.children.count()
+        winner.complete(Result.success(7))
+
+        val loser = async { singleFlight.run("k".asStreamTypedKey<Int>()) { 1 } }
+        advanceUntilIdle()
+
+        // The loser is served by the winner's result...
+        assertEquals(7, loser.await().getOrThrow())
+        // ...and its own never-started deferred is not left attached to the scope's Job.
+        assertEquals(childrenBefore, parent.children.count())
     }
 
     @Test


### PR DESCRIPTION
### Goal
Fixes [AND-1385](https://linear.app/stream/issue/AND-1385/singleflight-cancelled-caller-can-orphan-the-flight-and-cause) — a cancelled caller can break single-flight's dedup guarantee, causing the shared work to run twice.

`StreamSingleFlightProcessorImpl` evicts the in-flight map entry from the awaiting caller's `finally`. Because the shared work is detached in the processor scope, a cancelled installer removes the still-running job from the map while it keeps executing — the next caller for the same key misses and starts a second execution. Benign for token refresh (a redundant refresh); for the intended `Call.join` reuse it means two `RtcSession`s on one `sessionId` (SFU-evicted zombies). Surfaced reviewing stream-video-android#1764.

### Implementation
- Move eviction off the caller's `finally` onto the shared work itself: `newExecution.invokeOnCompletion { flights.remove(key, newExecution) }`. Removal is now terminal-state-driven — fires on success, block-failure, and external cancellation alike — so a cancelled awaiter can no longer collapse the dedup window.
- Conditional `remove(key, newExecution)` still leaves any newer flight that replaced the entry intact.
- Cancel the race-loser's unstarted `LAZY` deferred. `scope.async` attaches it to the scope's `Job` at construction, so a caller losing the `putIfAbsent` race otherwise leaves an inert child (holding its block + captures) attached for the scope's lifetime. (Pre-existing leak, reported by @gpunto.)

### Testing
`./gradlew :stream-android-core:testDebugUnitTest` — SingleFlight suite green, including four added regression tests:
- cancelled installer + a late caller stays single-execution (fails before the fix — two executions),
- coalescing holds for a newcomer after every current awaiter is cancelled,
- a run after a completed flight starts fresh (guards against replaying a completed `Deferred`),
- a race-loser leaves no unstarted child attached to the scope's `Job` (fails before the loser-leak fix).

Full module run is green except one pre-existing, unrelated failure (`StreamCompositeEventSerializationImplTest`, a brittle `declaredConstructors.first()` reflection test broken by a prior conventions bump — not touched by this change).